### PR TITLE
use pyproject.toml to pre-install numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "oldest-supported-numpy"]


### PR DESCRIPTION
Hi, thanks for the great package!

When we use miplib as a dependency, `setup.py` requires numpy to be pre-installed in order to [compile extensions](https://github.com/sakoho81/miplib/blob/public/setup.py#L29). To automate this, I suggest using `pyproject.toml` to specify packages required before running setup ([PEP518](https://www.python.org/dev/peps/pep-0518/)). [`oldest-supported-numpy`](https://numpy.org/devdocs/user/depending_on_numpy.html?highlight=mean#build-time-dependency) will specify the correct NumPy version at build time for wheels, taking into account Python version, Python implementation (CPython or PyPy), operating system and hardware platform.

Cheers!