### PR TITLE
Split ImageData: extract HDF5 store, remove active_image, add ImageKey

### DIFF
--- a/miplib/bin/fuse.py
+++ b/miplib/bin/fuse.py
@@ -19,6 +19,7 @@ import miplib.processing.fusion.fusion_cuda as gpufusion
 import miplib.processing.to_string as genutils
 import miplib.ui.cli.miplib_entry_point_options as arguments
 import miplib.ui.utils as uiutils
+from miplib.data.containers.image_data import ImageType
 
 
 def main():
@@ -32,15 +33,17 @@ def main():
 
     data = image_data.ImageData(full_path)
 
-    if options.scale not in data.get_scales("registered"):
+    if options.scale not in data.get_scales(ImageType.REGISTERED):
         print(
             "Images at the defined scale do not exist in the data structure."
             "The original images will be now resampled. This may take a long"
             "time depending on the image size and the number of views."
         )
-        data.create_rescaled_images("registered", options.scale)
+        data.create_rescaled_images(ImageType.REGISTERED, options.scale)
 
-    if data.get_number_of_images("psf") != data.get_number_of_images("registered"):
+    if data.get_number_of_images(ImageType.PSF) != data.get_number_of_images(
+        ImageType.REGISTERED
+    ):
         print(
             "Some PSFs are missing. They are going to be calculated from the "
             "original STED PSF (that is assumed to be at index 0)."

--- a/miplib/bin/import.py
+++ b/miplib/bin/import.py
@@ -94,7 +94,7 @@ def main():
         if not all(x in image_name for x in params_c) or not any(
             x in image_name for x in ImageType
         ):
-            print(f"Unrecognized image name {image_name}. Skipping it.")
+            print(f"Unrecognized file name pattern: {image_name}. Skipping.")
             continue
 
         image_type = image_name.split("_scale")[0]

--- a/miplib/bin/import.py
+++ b/miplib/bin/import.py
@@ -60,7 +60,8 @@ import sys
 import numpy
 
 from miplib.data.containers import image_data
-from miplib.data.definitions import image_types_c, params_c
+from miplib.data.containers.image_data import ImageKey, ImageType
+from miplib.data.definitions import params_c
 from miplib.data.io import read
 from miplib.processing import itk as itkutils
 
@@ -91,7 +92,7 @@ def main():
             images = (images * (255.0 / images.max())).astype(numpy.uint8)
 
         if not all(x in image_name for x in params_c) or not any(
-            x in image_name for x in image_types_c
+            x in image_name for x in ImageType
         ):
             print(f"Unrecognized image name {image_name}. Skipping it.")
             continue
@@ -103,7 +104,6 @@ def main():
         angle = image_name.split("angle_")[-1].split(".")[0]
 
         assert all(x.isdigit() for x in (scale, index, channel, angle))
-        # data, angle, spacing, index, scale, channel, chunk_size=None
 
         if image_type == "original":
             data.add_original_image(images, scale, index, channel, angle, spacing)
@@ -118,7 +118,7 @@ def main():
             print(
                 f"Creating {scale} percent downsampled versions of the original images"
             )
-            data.create_rescaled_images("original", scale)
+            data.create_rescaled_images(ImageType.ORIGINAL, scale)
 
     # Add transforms for registered images.
     for transform_name in os.listdir(directory):
@@ -140,12 +140,12 @@ def main():
         full_path = os.path.join(directory, transform_name)
 
         # First calculate registered image if not in the data structure
-        if not data.check_if_exists("registered", index, channel, scale):
+        if not data.check_if_exists(ImageType.REGISTERED, index, channel, scale):
             print("Resampling registered image for image nr. ", index)
-            data.set_active_image(0, channel, scale, "original")
-            reference = data.get_itk_image()
-            data.set_active_image(index, channel, scale, "original")
-            moving = data.get_itk_image()
+            key_ref = ImageKey(ImageType.ORIGINAL, 0, channel, scale)
+            key_moving = ImageKey(ImageType.ORIGINAL, index, channel, scale)
+            reference = data.get_itk_image(key_ref)
+            moving = data.get_itk_image(key_moving)
 
             transform = read.__itk_transform(full_path, return_itk=True)
 

--- a/miplib/bin/register.py
+++ b/miplib/bin/register.py
@@ -18,6 +18,7 @@ import sys
 import SimpleITK as sitk
 
 from miplib.data.containers import image_data
+from miplib.data.containers.image_data import ImageKey, ImageType
 from miplib.processing import itk as itkutils
 from miplib.processing.registration import registration_mv
 from miplib.ui import utils
@@ -38,21 +39,23 @@ def main():
     data = image_data.ImageData(full_path)
 
     # Check that requested image size exists. If not, create it.
-    if options.scale not in data.get_scales("original"):
+    if options.scale not in data.get_scales(ImageType.ORIGINAL):
         print(
             "Images at the defined scale do not exist in the data "
             "structure. The original images will be now resampled. "
             "This may take a long time depending on the image size "
             "and the number of views."
         )
-        data.create_rescaled_images("original", options.scale)
+        data.create_rescaled_images(ImageType.ORIGINAL, options.scale)
 
-    data.set_active_image(0, options.channel, options.scale, "original")
-    spacing = data.get_voxel_size()
-    data.add_registered_image(data[:], options.scale, 0, options.channel, 0, spacing)
+    key0 = ImageKey(ImageType.ORIGINAL, 0, options.channel, options.scale)
+    spacing = data.get_voxel_size(key0)
+    data.add_registered_image(
+        data.get_image_data(key0), options.scale, 0, options.channel, 0, spacing
+    )
 
     if options.evaluate_results:
-        fixed_image = data.get_itk_image()
+        fixed_image = data.get_itk_image(key0)
 
     # Setup registration. View number 0 is always the reference for now.
     # The behavior can be easily changed if necessary.
@@ -60,9 +63,11 @@ def main():
     task.set_fixed_image(0)
 
     # Iterate over the rotated views
-    for view in range(1, data.get_number_of_images("original")):
+    for view in range(1, data.get_number_of_images(ImageType.ORIGINAL)):
         task.set_moving_image(view)
-        if data.check_if_exists("registered", view, options.channel, options.scale):
+        if data.check_if_exists(
+            ImageType.REGISTERED, view, options.channel, options.scale
+        ):
             if utils.get_user_input(
                 "There is a saved registration result for "
                 "the view %i. Do you want to skip it?" % view

--- a/miplib/data/adapters/array_detector_data.py
+++ b/miplib/data/adapters/array_detector_data.py
@@ -4,16 +4,14 @@ Image objects in funcitons that were written for ArrayDetectorData.
 """
 
 from miplib.data.containers.image import Image
+from miplib.data.containers.image_data import ImageKey, ImageType
 
 
 class ImageDataAdapter:
-    def __init__(self, data, kind="original", scale=100):
+    def __init__(self, data, kind=ImageType.ORIGINAL, scale=100):
         self.data = data
-
-        self.kind = kind
+        self.kind = ImageType(kind) if isinstance(kind, str) else kind
         self.scale = scale
-
-        self.data.set_active_image(0, 0, self.scale, self.kind)
 
     @property
     def ndetectors(self):
@@ -25,11 +23,9 @@ class ImageDataAdapter:
 
     def __getitem__(self, item):
         gate, detector = item
-
-        self.data.set_active_image(detector, gate, self.scale, self.kind)
-        spacing = self.data.get_voxel_size()
-
-        return Image(self.data[:], spacing)
+        key = ImageKey(self.kind, detector, gate, self.scale)
+        spacing = self.data.get_voxel_size(key)
+        return Image(self.data.get_image_data(key), spacing)
 
 
 class ImageAdapter:

--- a/miplib/data/containers/image_data.py
+++ b/miplib/data/containers/image_data.py
@@ -40,36 +40,45 @@ class ImageData:
     # -- Read (convenience) ---------------------------------------------------
 
     def get_image(self, key: ImageKey) -> Image:
+        """Return the image at *key* as an :class:`Image` (ndarray + spacing)."""
         data = self._store.get_image_data(key)
         attrs = self._store.get_image_attributes(key)
         return Image(data, attrs["spacing"])
 
     def get_image_data(self, key: ImageKey) -> np.ndarray:
+        """Return the raw image array at *key*."""
         return self._store.get_image_data(key)
 
     def get_itk_image(self, key: ImageKey) -> "sitk.Image":
+        """Return the image at *key* as a SimpleITK image."""
         data = self._store.get_image_data(key)
         attrs = self._store.get_image_attributes(key)
         return itkutils.convert_from_numpy(data, attrs["spacing"])
 
     def get_voxel_size(self, key: ImageKey) -> list[float]:
+        """Return the voxel spacing as a list of floats."""
         return list(self._store.get_image_attributes(key)["spacing"])
 
     def get_image_size(self, key: ImageKey) -> tuple[int, ...]:
+        """Return the image dimensions (z, y, x) as a tuple."""
         size = self._store.get_image_attributes(key)["size"]
         return tuple(size)
 
     def get_max(self, key: ImageKey) -> float:
+        """Return the maximum pixel value in the image at *key*."""
         return float(self._store.get_image_data(key).max())
 
     def get_dtype(self, key: ImageKey) -> np.dtype:
+        """Return the numpy dtype of the image at *key*."""
         return self._store.get_image_data(key).dtype
 
     def get_rotation_angle(self, key: ImageKey, radians: bool = True) -> float:
+        """Return the rotation angle in radians (default) or degrees."""
         angle = float(self._store.get_image_attributes(key)["angle"])
         return np.pi * angle / 180.0 if radians else angle
 
     def get_transform(self, key: ImageKey) -> "sitk.Transform":
+        """Reconstruct the ITK spatial transform for a registered view."""
         attrs = self._store.get_image_attributes(key)
         ndim = len(attrs["size"])
         return itkutils.make_itk_transform(
@@ -79,6 +88,7 @@ class ImageData:
     def get_transform_parameters(
         self, key: ImageKey
     ) -> tuple[list[float], list[float], int]:
+        """Return the raw transform parameters, fixed parameters, and type."""
         attrs = self._store.get_image_attributes(key)
         return attrs["tfm_params"], attrs["tfm_fixed_params"], attrs["tfm_type"]
 
@@ -89,6 +99,7 @@ class ImageData:
         block_pad: int,
         block_start_index: np.ndarray,
     ) -> np.ndarray:
+        """Read a padded sub-block of a registered image."""
         return self._store.get_registered_block(
             key, block_size, block_pad, block_start_index
         )
@@ -105,6 +116,11 @@ class ImageData:
         spacing: Sequence[float],
         chunk_size: tuple[int, ...] | None = None,
     ) -> None:
+        """Add a source image.
+
+        If spacing is anisotropic (3D with z != xy), the data is resampled
+        to isotropic spacing before storage.
+        """
         if not isinstance(data, np.ndarray):
             raise TypeError(f"Expected numpy.ndarray, got {type(data).__name__}")
 
@@ -133,6 +149,10 @@ class ImageData:
         chunk_size: tuple[int, ...] | None = None,
         overwrite: bool = False,
     ) -> None:
+        """Add a registered (resampled) image.
+
+        If *overwrite* is ``False`` and the dataset exists, this is a no-op.
+        """
         if not isinstance(data, np.ndarray):
             raise TypeError(f"Expected numpy.ndarray, got {type(data).__name__}")
 
@@ -155,6 +175,7 @@ class ImageData:
         chunk_size: tuple[int, ...] | None = None,
         calculated: bool = False,
     ) -> None:
+        """Add a point-spread-function image."""
         if not isinstance(data, np.ndarray):
             raise TypeError(f"Expected numpy.ndarray, got {type(data).__name__}")
 
@@ -174,6 +195,7 @@ class ImageData:
         scale: int,
         spacing: Sequence[float],
     ) -> None:
+        """Add a fused (reconstructed) image."""
         if not isinstance(data, np.ndarray):
             raise TypeError(f"Expected numpy.ndarray, got {type(data).__name__}")
 
@@ -188,6 +210,7 @@ class ImageData:
         fixed_params: Sequence[float],
         transform_type: int,
     ) -> None:
+        """Attach spatial transform parameters to a registered view."""
         self._store.add_transform(
             index, channel, scale, params, fixed_params, transform_type
         )
@@ -195,9 +218,11 @@ class ImageData:
     # -- Query ----------------------------------------------------------------
 
     def get_number_of_images(self, image_type: ImageType | str) -> int:
+        """Return the number of view indices available for *image_type*."""
         return self._store.get_number_of_images(_resolve_type(image_type))
 
     def get_scales(self, image_type: ImageType | str) -> list[int]:
+        """Return the available scale levels for *image_type*."""
         return self._store.get_scales(_resolve_type(image_type))
 
     def check_if_exists(
@@ -207,6 +232,7 @@ class ImageData:
         channel: int,
         scale: int,
     ) -> bool:
+        """Return ``True`` if the specified image exists."""
         return self._store.check_if_exists(
             ImageKey(_resolve_type(image_type), index, channel, scale)
         )
@@ -219,27 +245,33 @@ class ImageData:
         scale: int,
         chunk_size: tuple[int, ...] | None = None,
     ) -> None:
+        """Downsample every image of *image_type* to *scale* percent."""
         idops.create_rescaled_images(
             self._store, _resolve_type(image_type), scale, chunk_size
         )
 
     def calculate_missing_psfs(self) -> None:
+        """Synthesize missing PSFs by rotating the first PSF per-view."""
         idops.calculate_missing_psfs(self._store)
 
     def copy_registration_result(self, from_scale: int, to_scale: int) -> None:
+        """Migrate registration transforms from one scale level to another."""
         idops.copy_registration_result(self._store, from_scale, to_scale)
 
     # -- Lifecycle ------------------------------------------------------------
 
     @property
     def series_count(self) -> int:
+        """Number of distinct original image views."""
         return self._store.series_count
 
     @property
     def channel_count(self) -> int:
+        """Number of color channels in the dataset."""
         return self._store.channel_count
 
     def close(self) -> None:
+        """Flush metadata and close the backing HDF5 file."""
         self._store.close()
 
     def __enter__(self) -> "ImageData":

--- a/miplib/data/containers/image_data.py
+++ b/miplib/data/containers/image_data.py
@@ -1,774 +1,249 @@
-import os
+import logging
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
-import h5py
-import numpy
+import numpy as np
 import scipy.ndimage as ndimage
 
+import miplib.data.image_data_operations as idops
 import miplib.processing.itk as itkutils
-import miplib.processing.ndarray as arrayutils
-import miplib.ui.utils as uiutils
 from miplib.data.containers.image import Image
-from miplib.data.definitions import image_types_c
+from miplib.data.containers.image_data_store import (
+    HDF5ImageStore,
+    ImageDataStore,
+    ImageKey,
+    ImageType,
+)
+
+if TYPE_CHECKING:
+    import SimpleITK as sitk
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_type(image_type: ImageType | str) -> ImageType:
+    if isinstance(image_type, ImageType):
+        return image_type
+    return ImageType(image_type)
 
 
 class ImageData:
+    """Multi-view microscopy data backed by an HDF5 file.
+
+    Compose an ``ImageDataStore`` for low-level I/O and expose convenience
+    accessors for image registration, fusion, and analysis pipelines.
     """
-    The data storage in miplib is based on a HDF5 file format. This
-    allows the efficient handing of large datasets
-    """
 
-    def __init__(self, path):
-        if not os.path.exists(os.path.dirname(path)):
-            os.mkdir(os.path.dirname(path))
-        assert path.endswith(".hdf5")
+    def __init__(self, path: str) -> None:
+        self._store: ImageDataStore = HDF5ImageStore(path)
 
-        if os.path.exists(path):
-            self.data = h5py.File(path, mode="r+")
-            self.series_count = self.data.attrs["series_count"]
-            self.channel_count = self.data.attrs["channel_count"]
-        else:
-            self.data = h5py.File(path, mode="w")
-            self.series_count = 0
-            self.channel_count = 1
+    # -- Read (convenience) ---------------------------------------------------
 
-            self.data.attrs["series_count"] = self.series_count
-            self.data.attrs["channel_count"] = self.channel_count
+    def get_image(self, key: ImageKey) -> Image:
+        data = self._store.get_image_data(key)
+        attrs = self._store.get_image_attributes(key)
+        return Image(data, attrs["spacing"])
 
-        self.active_image = None
+    def get_image_data(self, key: ImageKey) -> np.ndarray:
+        return self._store.get_image_data(key)
+
+    def get_itk_image(self, key: ImageKey) -> "sitk.Image":
+        data = self._store.get_image_data(key)
+        attrs = self._store.get_image_attributes(key)
+        return itkutils.convert_from_numpy(data, attrs["spacing"])
+
+    def get_voxel_size(self, key: ImageKey) -> list[float]:
+        return list(self._store.get_image_attributes(key)["spacing"])
+
+    def get_image_size(self, key: ImageKey) -> tuple[int, ...]:
+        size = self._store.get_image_attributes(key)["size"]
+        return tuple(size)
+
+    def get_max(self, key: ImageKey) -> float:
+        return float(self._store.get_image_data(key).max())
+
+    def get_dtype(self, key: ImageKey) -> np.dtype:
+        return self._store.get_image_data(key).dtype
+
+    def get_rotation_angle(self, key: ImageKey, radians: bool = True) -> float:
+        angle = float(self._store.get_image_attributes(key)["angle"])
+        return np.pi * angle / 180.0 if radians else angle
+
+    def get_transform(self, key: ImageKey) -> "sitk.Transform":
+        attrs = self._store.get_image_attributes(key)
+        ndim = len(attrs["size"])
+        return itkutils.make_itk_transform(
+            attrs["tfm_type"], ndim, attrs["tfm_params"], attrs["tfm_fixed_params"]
+        )
+
+    def get_transform_parameters(
+        self, key: ImageKey
+    ) -> tuple[list[float], list[float], int]:
+        attrs = self._store.get_image_attributes(key)
+        return attrs["tfm_params"], attrs["tfm_fixed_params"], attrs["tfm_type"]
+
+    def get_registered_block(
+        self,
+        key: ImageKey,
+        block_size: np.ndarray,
+        block_pad: int,
+        block_start_index: np.ndarray,
+    ) -> np.ndarray:
+        return self._store.get_registered_block(
+            key, block_size, block_pad, block_start_index
+        )
+
+    # -- Write ----------------------------------------------------------------
 
     def add_original_image(
-        self, data, scale, index, channel, angle, spacing, chunk_size=None
-    ):
-        """
-        Add a source image to the HDF5 file.
+        self,
+        data: np.ndarray,
+        scale: int,
+        index: int,
+        channel: int,
+        angle: float,
+        spacing: Sequence[float],
+        chunk_size: tuple[int, ...] | None = None,
+    ) -> None:
+        if not isinstance(data, np.ndarray):
+            raise TypeError(f"Expected numpy.ndarray, got {type(data).__name__}")
 
-        Parameters
-        ----------
-        :param data:            Contains an image from a single rotation angle.
-                                The data should be in numpy.ndarray format.
-                                Multi-channel data is expected to be a 4D array
-                                in which the color channel is the first
-                                dimension.
-        :param scale            Percentage from full size. It is possible to save
-                                multiple versions of an image in different sizes.
-        :param index            The image ordering index
-        :param channel          The color channel to be associated with the image.
-        :param angle:           Estimated rotation angle of the view, in
-                                respect to the regular STED angle
-        :param spacing:         Voxel size
-
-        :param chunk_size:      A specific chunk size can be defined here in
-                                order to optimize the data access, when
-                                working with partial images.
-        :return:
-        """
-        assert isinstance(data, numpy.ndarray), "Invalid data format."
-
-        # if int(channel) > self.channel_count + 1:
-        #     raise ValueError("Add the color channels in the correct order")
-
-        # Create a new image group, based on the ordering index. If the
-        # group exists, an attempt is made to add a new dataset.
-        group_name = "original/" + str(index)
-        if group_name not in self.data:
-            image_group = self.data.create_group(group_name)
-            self.series_count += 1
-            self.data.attrs["series_count"] = self.series_count
-        else:
-            image_group = self.data[group_name]
-
-        name = "channel_" + str(channel) + "_scale_" + str(scale)
-
-        # Don't overwrite an existing image.
-        if name in image_group:
-            return
-
-        # Zoom axial dimension for isotropic pixel size.
         if data.ndim == 3 and spacing[0] != spacing[1]:
-            print(
-                f"Image index {index} needs to be resampled for isotropic spacing."
-                "This will take a minute"
-            )
+            logger.info("Image index %d resampled for isotropic spacing.", index)
             z_zoom = spacing[0] / spacing[1]
             data = ndimage.zoom(data, (z_zoom, 1, 1), order=3)
-            spacing = tuple(
-                spacing[x] if x != 0 else spacing[x] / z_zoom
-                for x in range(len(spacing))
-            )
+            spacing = tuple(s if i != 0 else s / z_zoom for i, s in enumerate(spacing))
 
-        # Activate chunked storage of requested
-        if chunk_size is None:
-            image_group.create_dataset(name, data=data)
-        else:
-            image_group.create_dataset(name, data=data, chunks=chunk_size)
-
-        image_group[name].attrs["angle"] = angle
-        image_group[name].attrs["spacing"] = spacing
-        image_group[name].attrs["size"] = data.shape
-
-        # # The first image is the same in the registered group as well,
-        # # so a soft link will be created here.
-        # if int(index) == 0:
-        #     reg_group_name = "registered/" + index
-        #     reg_group = self.data.create_group(reg_group_name)
-        #     reg_group[name] = image_group[name]
+        self._store.add_image(
+            ImageKey(ImageType.ORIGINAL, index, channel, scale),
+            data,
+            angle,
+            spacing,
+            chunk_size,
+        )
 
     def add_registered_image(
-        self, data, scale, index, channel, angle, spacing, chunk_size=None
-    ):
-        """
-        Add a registered/resampled image to the HDF5 file.
+        self,
+        data: np.ndarray,
+        scale: int,
+        index: int,
+        channel: int,
+        angle: float,
+        spacing: Sequence[float],
+        chunk_size: tuple[int, ...] | None = None,
+        overwrite: bool = False,
+    ) -> None:
+        if not isinstance(data, np.ndarray):
+            raise TypeError(f"Expected numpy.ndarray, got {type(data).__name__}")
 
-        Parameters
-        ----------
-        :param data:            Contains an image from a single rotation angle.
-                                The data should be in numpy.ndarray format.
-                                Multi-channel data is expected to be a 4D array
-                                in which the color channel is the first
-                                dimension.
-        :param scale            Percentage from full size. It is possible to save
-                                multiple versions of an image in different sizes.
-        :param index            The image ordering index
-        :param channel          The color channel to be associated with the image.
-        :param angle:           Estimated rotation angle of the view, in
-                                respect to the regular STED angle
-        :param spacing:         Voxel size
-
-        :param chunk_size:      A specific chunk size can be defined here in
-                                order to optimize the data access, when
-                                working with partial images.
-        :return:
-        """
-        assert isinstance(data, numpy.ndarray), "Invalid data format."
-
-        group_name = "registered/" + str(index)
-        if group_name not in self.data:
-            image_group = self.data.create_group(group_name)
-        else:
-            image_group = self.data[group_name]
-
-        # if channel > 0:
-        #     if self.channel_count == 1:
-        #         raise ValueError("Invalid channel count")
-
-        name = "channel_" + str(channel) + "_scale_" + str(scale)
-        if name in image_group:
-            if uiutils.get_user_input(
-                f"The dataset {name} already exists in image "
-                f"group {group_name}. Do you want to overwrite "
-                "it? "
-            ):
-                del image_group[name]
-            else:
+        key = ImageKey(ImageType.REGISTERED, index, channel, scale)
+        if self._store.check_if_exists(key):
+            if not overwrite:
                 return
+            self._store.delete_dataset(key)
 
-        if chunk_size is None:
-            image_group.create_dataset(name, data=data)
-        else:
-            image_group.create_dataset(name, data=data, chunks=chunk_size)
-
-        # Each image has its own attributes
-        image_group[name].attrs["angle"] = angle
-        image_group[name].attrs["spacing"] = spacing
-        image_group[name].attrs["size"] = data.shape
+        self._store.add_image(key, data, angle, spacing, chunk_size)
 
     def add_psf(
         self,
-        data,
-        scale,
-        index,
-        channel,
-        angle,
-        spacing,
-        chunk_size=None,
-        calculated=False,
-    ):
-        """
-        Add a PSF image to the HDF5 file.
+        data: np.ndarray,
+        scale: int,
+        index: int,
+        channel: int,
+        angle: float,
+        spacing: Sequence[float],
+        chunk_size: tuple[int, ...] | None = None,
+        calculated: bool = False,
+    ) -> None:
+        if not isinstance(data, np.ndarray):
+            raise TypeError(f"Expected numpy.ndarray, got {type(data).__name__}")
 
-        Parameters
-        ----------
-        :param data:            Contains an image from a single rotation angle.
-                                The data should be in numpy.ndarray format.
-                                Multi-channel data is expected to be a 4D array
-                                in which the color channel is the first
-                                dimension.
-        :param scale            Percentage from full size. It is possible to save
-                                multiple versions of an image in different sizes.
-        :param index            The image ordering index
-        :param channel          The color channel to be associated with the image.
-        :param angle:           Estimated rotation angle of the view, in
-                                respect to the regular STED angle
-        :param spacing:         Voxel size
+        self._store.add_image(
+            ImageKey(ImageType.PSF, index, channel, scale),
+            data,
+            angle,
+            spacing,
+            chunk_size,
+            calculated,
+        )
 
-        :param chunk_size:      A specific chunk size can be defined here in
-                                order to optimize the data access, when
-                                working with partial images.
-        :return:
-        """
+    def add_fused_image(
+        self,
+        data: np.ndarray,
+        channel: int,
+        scale: int,
+        spacing: Sequence[float],
+    ) -> None:
+        if not isinstance(data, np.ndarray):
+            raise TypeError(f"Expected numpy.ndarray, got {type(data).__name__}")
 
-        assert isinstance(data, numpy.ndarray), "Invalid data format."
-
-        group_name = "psf/" + str(index)
-        if group_name not in self.data:
-            image_group = self.data.create_group(group_name)
-        else:
-            image_group = self.data[group_name]
-
-        name = "channel_" + str(channel) + "_scale_" + str(scale)
-        if name in image_group:
-            return
-
-        if chunk_size is None:
-            image_group.create_dataset(name, data=data)
-        else:
-            image_group.create_dataset(name, data=data, chunks=chunk_size)
-
-        image_group[name].attrs["angle"] = angle
-        image_group[name].attrs["spacing"] = spacing
-        image_group[name].attrs["size"] = data.shape
-        image_group[name].attrs["calculated"] = calculated
+        self._store.add_fused_image(channel, scale, data, spacing)
 
     def add_transform(
-        self, scale, index, channel, params, fixed_params, transform_type
-    ):
-        """
-        Adds a spatial transformation as an attribute to the corresponding registered
-        view. This means that the registered/resampled image has to be added first, otherwise
-        an error is raised.
-
-        Parameters
-        ----------
-        :param scale            The scale, index and channel parameters identify the
-        :param index            registered view, the transform is associated with.
-        :param channel
-
-        :param params           The transform parameters. Usually what comes out of
-                                transform.GetParameters()
-        :param fixed_params     The transform fixed parameters (origin). Usually
-                                what comes out of transform.GetFixedParameters()
-        :param transform_type
-        """
-        name = (
-            "registered/"
-            + str(index)
-            + "/channel_"
-            + str(channel)
-            + "_scale_"
-            + str(scale)
+        self,
+        scale: int,
+        index: int,
+        channel: int,
+        params: Sequence[float],
+        fixed_params: Sequence[float],
+        transform_type: int,
+    ) -> None:
+        self._store.add_transform(
+            index, channel, scale, params, fixed_params, transform_type
         )
 
-        if name not in self.data:
-            raise ValueError(f"Dataset {name} does not exist")
-
-        self.data[name].attrs["tfm_type"] = transform_type
-        self.data[name].attrs["tfm_params"] = params
-        self.data[name].attrs["tfm_fixed_params"] = fixed_params
-
-    def add_fused_image(self, data, channel, scale, spacing):
-        """
-        Add a fused image.
-
-        :param data:            Contains an image from a single rotation angle.
-                                The data should be in numpy.ndarray format.
-                                Multi-channel data is expected to be a 4D array
-                                in which the color channel is the first
-                                dimension.
-        :param channel          The color channel to be associated with the image.
-        :param scale            Percentage from full size. It is possible to save
-                                multiple versions of an image in different sizes.
-        :param spacing:         Voxel size
-
-        """
-        assert isinstance(data, numpy.ndarray), "Invalid data format."
-
-        if "fused" not in self.data:
-            image_group = self.data.create_group("fused")
-        else:
-            image_group = self.data["fused"]
-
-        if channel > 0 and self.channel_count == 1:
-            raise ValueError("Invalid channel count")
-
-        name = "channel_" + str(channel) + "_scale_" + str(scale)
-        if name in image_group:
-            return
-
-        image_group.create_dataset(name, data=data)
-        image_group[name].attrs["spacing"] = spacing
-
-    def create_rescaled_images(self, type, scale, chunk_size=None):
-        """
-        Creates rescaled versions of images of a given type. The scaled images
-        are saved directly into the HDF5 file.
-
-        Parameters
-        ----------
-        type        The image type
-        scale       Scale is the percentage of the original image size.
-        chunk_size  The same as with the other images. Can be used to define a
-                    particular chunk size for data storage.
-        """
-        if scale in self.get_scales(type):
-            if uiutils.get_user_input(
-                "The scale %i already exists for the image type "
-                "%s. Do you want to recalculate?" % (scale, type)
-            ):
-                pass
-            else:
-                return
-        # Iterate over all the images
-        for index in range(self.get_number_of_images(type)):
-            group_name = type + "/" + str(index)
-            image_group = self.data[group_name]
-            # Iterate over channels
-            for channel in range(self.channel_count):
-                name_new = "channel_" + str(channel) + "_scale_" + str(scale)
-                name_ref = "channel_" + str(channel) + "_scale_100"
-                # Check if exists and delete if yes.
-                if name_new in image_group:
-                    del image_group[name_new]
-                    continue
-
-                # Zoom
-                spacing = tuple(
-                    100 * x / scale for x in image_group[name_ref].attrs["spacing"]
-                )
-                z_factor = float(scale) / 100
-                zoom = (z_factor,) * self.get_number_of_dimensions()
-                data = ndimage.zoom(image_group[name_ref], zoom, order=3)
-
-                if chunk_size is None:
-                    image_group.create_dataset(name_new, data=data)
-                else:
-                    image_group.create_dataset(name_new, data=data, chunks=chunk_size)
-
-                image_group[name_new].attrs["angle"] = image_group[name_ref].attrs[
-                    "angle"
-                ]
-                image_group[name_new].attrs["spacing"] = spacing
-                image_group[name_new].attrs["size"] = data.shape
-
-    def calculate_missing_psfs(self):
-        """
-        In case separate PSFs were not recorded for every view, the missing PSFs can be
-        calculated here before image fusion. This requires that the spatial transform
-        is available for every registered view.
-        """
-        max_scale = max(self.get_scales("registered"))
-        if max_scale < 100:
-            if uiutils.get_user_input(
-                "There is no registration result "
-                "available for the original images. The "
-                "largest available scale is %i. Do you "
-                "want to proceed with that? " % max_scale
-            ):
-                pass
-            else:
-                raise ValueError("No suitable registration result available.")
-
-        for channel in range(self.channel_count):
-            self.set_active_image(0, channel, 100, "psf")
-            image_spacing = self.get_voxel_size()
-            psf_orig = self.data[self.active_image][:]
-
-            for index in range(1, self.get_number_of_images("registered")):
-                if not self.check_if_exists("psf", index, channel, 100):
-                    self.set_active_image(index, channel, max_scale, "registered")
-                    transform = self.get_transform()
-                    psf_new = itkutils.rotate_psf(
-                        psf_orig, transform, image_spacing, return_numpy=True
-                    )
-                    self.add_psf(
-                        psf_new,
-                        100,
-                        index,
-                        channel,
-                        self.get_rotation_angle(),
-                        image_spacing,
-                        calculated=True,
-                    )
-
-    def copy_registration_result(self, from_scale, to_scale):
-        """
-        With this function it is possible
-        to migrate the registration results from one scale to another.
-
-        With very large images it is sometimes easier and faster to perform
-        image registration with downsampled versions of the original images.
-        The accuracy of the registration result is often very good, even with
-        60 percent downsampled images.
-
-        Parameters
-        ----------
-        :item from_scale    The scale for which there is an existing
-                            registration result.
-        :item to_scale      The scale for which the new registration results
-                            should be calculated.
-
-        Returns
-        -------
-
-        """
-
-        # Check that the registration result for the specified scale
-        # exists.
-        assert from_scale in self.get_scales("registered")
-        print(
-            "Copying registration results from %i to %i percent scale"
-            % (from_scale, to_scale)
-        )
-        if to_scale not in self.get_scales("original"):
-            self.create_rescaled_images("original", to_scale)
-
-        for channel in range(self.channel_count):
-            print("Resampling view 0")
-            self.set_active_image(0, channel, to_scale, "original")
-            self.add_registered_image(
-                self.data[self.active_image][:],
-                to_scale,
-                0,
-                channel,
-                0,
-                self.get_voxel_size(),
-            )
-            self.set_active_image(0, channel, to_scale, "registered")
-            reference = self.get_itk_image()
-
-            for view in range(1, self.get_number_of_images("original")):
-                print("Resampling view %i" % view)
-                self.set_active_image(view, channel, from_scale, "registered")
-                transform = self.get_transform()
-                transform_params = self.get_transform_parameters()
-                self.set_active_image(view, channel, to_scale, "original")
-                image = self.get_itk_image()
-                angle = self.get_rotation_angle(radians=False)
-                spacing = self.get_voxel_size()
-                result = itkutils.convert_from_itk_image(
-                    itkutils.resample_image(image, transform, reference=reference)
-                )[0]
-                self.add_registered_image(
-                    result, to_scale, view, channel, angle, spacing
-                )
-                self.add_transform(
-                    to_scale,
-                    view,
-                    channel,
-                    transform_params[0],
-                    transform_params[1],
-                    transform_params[2],
-                )
-
-                #  def add_transform(self, scale, index, channel, params, fixed_params, transform_type):
-
-    def get_rotation_angle(self, radians=True):
-        """
-        Get rotation angle of the currently active image.
-
-        Parameters
-        ----------
-        radians     Use radians instead of degrees
-
-        Returns
-        -------
-        Returns the rotation angle, as degrees or radians
-        """
-        if radians:
-            angle = numpy.pi * int(self.data[self.active_image].attrs["angle"]) / 180
-            return angle
-        else:
-            return int(self.data[self.active_image].attrs["angle"])
-
-    def get_voxel_size(self):
-        """
-        Get the voxel size of the currently active image.
-
-        Returns
-        -------
-        Voxel size as a three element tuple (assuming 3D image).
-        """
-        return list(self.data[self.active_image].attrs["spacing"])
-
-    def get_max(self):
-        return self.data[self.active_image][:].max()
-
-    def get_image_size(self):
-        """
-        Get dimensions of the currently active image
-
-        Returns
-        -------
-        Image dimensions as a tuple.
-        """
-        return self.data[self.active_image].attrs["size"]
-
-    def get_dtype(self):
-        """
-        Get the datatype of the currently acitve image
-
-        Returns
-        -------
-        The datatype as a numpy.dtype compatible parameter
-        """
-        return self.data[self.active_image].dtype
-
-    def get_number_of_images(self, image_type):
-        """
-        Get the number of images of a given type stored in the data structure
-
-        Parameters
-        ----------
-        :param image_type     The image type
-
-        Returns
-        -------
-        The number of images of a given type.
-
-        """
-        assert image_type in image_types_c
-        return len(self.data[image_type])
-
-    def get_number_of_dimensions(self):
-        return self.data[self.active_image].ndim
-
-    def get_scales(self, image_type):
-        """
-        Get a list of the image sizes available for a given image type.
-
-        Parameters
-        ----------
-        :param image_type       The image type
-
-        Returns
-        -------
-        Returns a list of the saved scales. Raises an error if the scales
-        have been saved inconsistently, i.e. all images of the same type
-        do not have the same scales available.
-        """
-
-        assert image_type in image_types_c
-        scales = []
-
-        def find_scale(name):
-            scales.append(int(name.split("_")[-1]))
-
-        for index in range(self.get_number_of_images(image_type)):
-            scales = []
-            group_name = image_type + "/" + str(index)
-            image_group = self.data[group_name]
-            image_group.visit(find_scale)
-
-            if index == 0:
-                scales_ref = scales
-            else:
-                if set(scales_ref) != set(scales):
-                    raise ValueError(
-                        "Database error. Resampled images have not been"
-                        f"saved consistently for image type {image_type}"
-                    )
-
-        return scales
-
-    def get_transform(self):
-        """
-        Get the spatial transformation of the current registered view. Requires a
-        registered view to be set as active.
-
-        Returns
-        -------
-        Return an ITK spatial transform.
-        """
-        assert "registered" in self.active_image
-        tfm_type = self.data[self.active_image].attrs["tfm_type"]
-        tfm_params = self.data[self.active_image].attrs["tfm_params"]
-        tfm_fixed_params = self.data[self.active_image].attrs["tfm_fixed_params"]
-        ndim = self.get_number_of_dimensions()
-
-        return itkutils.make_itk_transform(tfm_type, ndim, tfm_params, tfm_fixed_params)
-
-    def get_transform_parameters(self):
-        assert "registered" in self.active_image
-        tfm_type = self.data[self.active_image].attrs["tfm_type"]
-        tfm_params = self.data[self.active_image].attrs["tfm_params"]
-        tfm_fixed_params = self.data[self.active_image].attrs["tfm_fixed_params"]
-
-        return tfm_params, tfm_fixed_params, tfm_type
-
-    def set_active_image(self, index, channel, scale, image_type):
-        """
-        Select which view is currently active.
-
-        :param index:       View index, goes from 0 to number of views - 1
-        :param channel      The currently active color channel. Goes from 0 to
-                            number of channels - 1
-        :param scale        Image size, as a percentage of the full size.
-        :param image_type   Image type as a string, listed in image_types_c
-        """
-        if int(index) >= self.series_count:
-            print(
-                "Invalid index. There are only %i images in the file"
-                % self.series_count
-            )
-            return
-        elif image_type not in image_types_c:
-            print("Unkown image type.")
-            return
-        else:
-            if image_type == "fused":
-                self.active_image = (
-                    image_type + "/channel_" + str(channel) + "_scale_" + str(scale)
-                )
-            else:
-                self.active_image = (
-                    image_type
-                    + "/"
-                    + str(index)
-                    + "/channel_"
-                    + str(channel)
-                    + "_scale_"
-                    + str(scale)
-                )
-            if self.active_image not in self.data:
-                raise ValueError(f"No such image: {self.active_image}")
-
-    # def set_fused_block(self, block, start_index):
-    #     assert isinstance(block, numpy.ndarray) and isinstance(start_index, numpy.ndarray)
-    #     stop_index = start_index + block.shape
-    #     self.data["fused"][start_index:stop_index] = block
-
-    def get_registered_block(self, block_size, block_pad, block_start_index):
-        """
-        When fusing large images, it is often necessary to divide the images
-        into several blocks in order to keep the memory requirements at bay.
-        For such use cases functionality was added here to read a partial image
-        of a given block size and start index directly from disk. Padding is
-        supported as well.
-
-        Parameters
-        ----------
-        :param block_size   The size of the desired block
-        :param block_pad    The amount of padding to be applied to the sides of the
-                            block. This kind of partial overlap of adjacent blocks is
-                            needed to avoid fusion artifacts at the block boundaries.
-
-        :param block_start_index
-                            The index pointing to the beginning of the block.
-
-        Returns
-        -------
-        The padded image block as a 3D numpy array.
-
-        """
-        assert isinstance(block_size, numpy.ndarray)
-
-        assert "registered" in self.active_image, "You must specify a registered image"
-
-        image_size = self.data[self.active_image].shape
-
-        # Apply padding
-        end_index = block_start_index + block_size + block_pad
-        start_index = block_start_index - block_pad
-        # print "Getting a block from ", self.active_image
-        # print "The start index is %i %i %i" % tuple(start_index)
-        # print "The block size is %i %i %i" % tuple(block_size)
-
-        block_idx = arrayutils.start_to_stop_idx(start_index, end_index)
-
-        if (image_size >= end_index).all() and (start_index >= 0).all():
-            block = self.data[self.active_image][block_idx]
-            return block
-
-        else:
-            pad_block_size = block_size + 2 * block_pad
-            block = numpy.zeros(pad_block_size)
-
-            # If the start_index is close to the image boundaries, it is very
-            # probable that padding will introduce negative start_index values.
-            # In such case the first pixel index must be corrected.
-            if (start_index < 0).any():
-                block_start = numpy.negative(start_index.clip(max=0))
-                image_start = start_index + block_start
-            else:
-                block_start = (0, 0, 0)
-                image_start = start_index
-            # If the padded block is larger than the image size the
-            # block_size must be adjusted.
-            if not (image_size >= end_index).all():
-                block_crop = end_index - image_size
-                block_crop[block_crop < 0] = 0
-                block_end = pad_block_size - block_crop
-            else:
-                block_end = pad_block_size
-
-            end_index = start_index + block_end
-
-            block_read_idx = arrayutils.start_to_stop_idx(image_start, end_index)
-            block_write_idx = arrayutils.start_to_stop_idx(block_start, block_end)
-
-            block[block_write_idx] = self.data[self.active_image][block_read_idx]
-            return block
-
-    def get_itk_image(self):
-        """
-        Get the currently active image as a ITK image instead of a Numpy array.
-        """
-        return itkutils.convert_from_numpy(
-            self.data[self.active_image][:],
-            self.data[self.active_image].attrs["spacing"],
+    # -- Query ----------------------------------------------------------------
+
+    def get_number_of_images(self, image_type: ImageType | str) -> int:
+        return self._store.get_number_of_images(_resolve_type(image_type))
+
+    def get_scales(self, image_type: ImageType | str) -> list[int]:
+        return self._store.get_scales(_resolve_type(image_type))
+
+    def check_if_exists(
+        self,
+        image_type: ImageType | str,
+        index: int,
+        channel: int,
+        scale: int,
+    ) -> bool:
+        return self._store.check_if_exists(
+            ImageKey(_resolve_type(image_type), index, channel, scale)
         )
 
-    def get_image(self):
-        """
-        Get the currently active image as an Image object instead of a Numpy array
-        """
-        return Image(
-            self.data[self.active_image][:],
-            self.data[self.active_image].attrs["spacing"],
+    # -- Derived image operations ---------------------------------------------
+
+    def create_rescaled_images(
+        self,
+        image_type: ImageType | str,
+        scale: int,
+        chunk_size: tuple[int, ...] | None = None,
+    ) -> None:
+        idops.create_rescaled_images(
+            self._store, _resolve_type(image_type), scale, chunk_size
         )
 
-    def get_active_image_index(self):
-        """
-        Get the image of the currently active image
-        """
-        return self.active_image.split("/")[1]
+    def calculate_missing_psfs(self) -> None:
+        idops.calculate_missing_psfs(self._store)
 
-    def close(self):
-        """
-        Close the file object.
-        """
-        self.data.attrs["series_count"] = self.series_count
-        self.data.attrs["channel_count"] = self.channel_count
+    def copy_registration_result(self, from_scale: int, to_scale: int) -> None:
+        idops.copy_registration_result(self._store, from_scale, to_scale)
 
-        self.data.close()
+    # -- Lifecycle ------------------------------------------------------------
 
-    def check_if_exists(self, image_type, index, channel, scale):
-        """
-        Check if the specified image already exists in the data structure.
+    @property
+    def series_count(self) -> int:
+        return self._store.series_count
 
-        Parameters
-        ----------
-        :param image_type         The parameters needed to identify an image in the
-        :param index        data structure.
-        :param channel
-        :param scale
+    @property
+    def channel_count(self) -> int:
+        return self._store.channel_count
 
-        Returns
-        -------
-        True if Yes, False if No.
-        """
-        name = (
-            image_type
-            + "/"
-            + str(index)
-            + "/channel_"
-            + str(channel)
-            + "_scale_"
-            + str(scale)
-        )
-        return name in self.data
+    def close(self) -> None:
+        self._store.close()
 
-    def __getitem__(self, item):
-        return self.data[self.active_image][item]
+    def __enter__(self) -> "ImageData":
+        return self
 
-    def __setitem__(self, key, value):
-        self.data[self.active_image][key] = value
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/miplib/data/containers/image_data_store.py
+++ b/miplib/data/containers/image_data_store.py
@@ -1,0 +1,312 @@
+import logging
+import os
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Protocol
+
+import h5py
+import numpy as np
+
+import miplib.processing.ndarray as arrayutils
+
+logger = logging.getLogger(__name__)
+
+
+class ImageType(StrEnum):
+    ORIGINAL = "original"
+    REGISTERED = "registered"
+    FUSED = "fused"
+    PSF = "psf"
+
+
+@dataclass(frozen=True)
+class ImageKey:
+    image_type: ImageType
+    index: int
+    channel: int = 0
+    scale: int = 100
+
+    def to_path(self) -> str:
+        if self.image_type == ImageType.FUSED:
+            return f"fused/channel_{self.channel}_scale_{self.scale}"
+        return (
+            f"{self.image_type.value}/{self.index}"
+            f"/channel_{self.channel}_scale_{self.scale}"
+        )
+
+
+class ImageDataStore(Protocol):
+    """Protocol defining the storage interface for multi-view image data."""
+
+    @property
+    def series_count(self) -> int: ...
+
+    @property
+    def channel_count(self) -> int: ...
+
+    def add_image(
+        self,
+        key: ImageKey,
+        data: np.ndarray,
+        angle: float,
+        spacing: Sequence[float],
+        chunk_size: tuple[int, ...] | None = None,
+        calculated: bool | None = None,
+    ) -> None: ...
+
+    def add_fused_image(
+        self,
+        channel: int,
+        scale: int,
+        data: np.ndarray,
+        spacing: Sequence[float],
+    ) -> None: ...
+
+    def add_transform(
+        self,
+        index: int,
+        channel: int,
+        scale: int,
+        params: Sequence[float],
+        fixed_params: Sequence[float],
+        transform_type: int,
+    ) -> None: ...
+
+    def get_image_data(self, key: ImageKey) -> np.ndarray: ...
+
+    def get_image_attributes(self, key: ImageKey) -> dict[str, Any]: ...
+
+    def get_registered_block(
+        self,
+        key: ImageKey,
+        block_size: np.ndarray,
+        block_pad: int,
+        block_start_index: np.ndarray,
+    ) -> np.ndarray: ...
+
+    def get_number_of_images(self, image_type: ImageType) -> int: ...
+
+    def get_scales(self, image_type: ImageType) -> list[int]: ...
+
+    def check_if_exists(self, key: ImageKey) -> bool: ...
+
+    def delete_dataset(self, key: ImageKey) -> None: ...
+
+    def close(self) -> None: ...
+
+
+class HDF5ImageStore:
+    """HDF5-backed implementation of ImageDataStore."""
+
+    def __init__(self, path: str) -> None:
+        directory = os.path.dirname(path) or "."
+        os.makedirs(directory, exist_ok=True)
+
+        if os.path.exists(path):
+            self._file = h5py.File(path, mode="r+")
+            self._series_count = int(self._file.attrs["series_count"])
+            self._channel_count = int(self._file.attrs["channel_count"])
+        else:
+            self._file = h5py.File(path, mode="w")
+            self._series_count = 0
+            self._channel_count = 1
+            self._file.attrs["series_count"] = self._series_count
+            self._file.attrs["channel_count"] = self._channel_count
+
+    @property
+    def series_count(self) -> int:
+        return self._series_count
+
+    @property
+    def channel_count(self) -> int:
+        return self._channel_count
+
+    def add_image(
+        self,
+        key: ImageKey,
+        data: np.ndarray,
+        angle: float,
+        spacing: Sequence[float],
+        chunk_size: tuple[int, ...] | None = None,
+        calculated: bool | None = None,
+    ) -> None:
+        if not isinstance(data, np.ndarray):
+            raise TypeError(f"Expected numpy.ndarray, got {type(data).__name__}")
+
+        group_path = f"{key.image_type.value}/{key.index}"
+        if group_path not in self._file:
+            self._file.create_group(group_path)
+            if key.image_type == ImageType.ORIGINAL:
+                self._series_count += 1
+                self._file.attrs["series_count"] = self._series_count
+
+        dataset_name = f"channel_{key.channel}_scale_{key.scale}"
+        if dataset_name in self._file[group_path]:
+            return
+
+        image_group = self._file[group_path]
+        if chunk_size is None:
+            image_group.create_dataset(dataset_name, data=data)
+        else:
+            image_group.create_dataset(dataset_name, data=data, chunks=chunk_size)
+
+        dataset = image_group[dataset_name]
+        dataset.attrs["angle"] = float(angle)
+        dataset.attrs["spacing"] = list(spacing)
+        dataset.attrs["size"] = data.shape
+
+        if calculated is not None:
+            dataset.attrs["calculated"] = calculated
+
+    def add_fused_image(
+        self,
+        channel: int,
+        scale: int,
+        data: np.ndarray,
+        spacing: Sequence[float],
+    ) -> None:
+        if not isinstance(data, np.ndarray):
+            raise TypeError(f"Expected numpy.ndarray, got {type(data).__name__}")
+
+        if "fused" not in self._file:
+            image_group = self._file.create_group("fused")
+        else:
+            image_group = self._file["fused"]
+
+        name = f"channel_{channel}_scale_{scale}"
+        if name in image_group:
+            return
+
+        image_group.create_dataset(name, data=data)
+        image_group[name].attrs["spacing"] = list(spacing)
+
+    def add_transform(
+        self,
+        index: int,
+        channel: int,
+        scale: int,
+        params: Sequence[float],
+        fixed_params: Sequence[float],
+        transform_type: int,
+    ) -> None:
+        path = f"registered/{index}/channel_{channel}_scale_{scale}"
+        if path not in self._file:
+            raise ValueError(f"Registered dataset {path} does not exist")
+
+        dataset = self._file[path]
+        dataset.attrs["tfm_type"] = transform_type
+        dataset.attrs["tfm_params"] = list(params)
+        dataset.attrs["tfm_fixed_params"] = list(fixed_params)
+
+    def get_image_data(self, key: ImageKey) -> np.ndarray:
+        return self._file[key.to_path()][:]
+
+    def get_image_attributes(self, key: ImageKey) -> dict[str, Any]:
+        raw = dict(self._file[key.to_path()].attrs)
+        result: dict[str, Any] = {}
+        for k, v in raw.items():
+            if isinstance(v, np.ndarray):
+                result[k] = v.tolist()
+            elif isinstance(v, (np.integer, np.floating)):
+                result[k] = v.item()
+            elif isinstance(v, np.bool_):
+                result[k] = bool(v)
+            else:
+                result[k] = v
+        return result
+
+    def get_registered_block(
+        self,
+        key: ImageKey,
+        block_size: np.ndarray,
+        block_pad: int,
+        block_start_index: np.ndarray,
+    ) -> np.ndarray:
+        if key.image_type != ImageType.REGISTERED:
+            raise ValueError(
+                f"get_registered_block requires a REGISTERED key, got {key.image_type}"
+            )
+
+        image_size = np.array(self._file[key.to_path()].shape)
+        end_index = block_start_index + block_size + block_pad
+        start_index = block_start_index - block_pad
+        block_idx = arrayutils.start_to_stop_idx(start_index, end_index)
+
+        if (image_size >= end_index).all() and (start_index >= 0).all():
+            return self._file[key.to_path()][block_idx]
+
+        pad_block_size = block_size + 2 * block_pad
+        block = np.zeros(pad_block_size)
+
+        if (start_index < 0).any():
+            block_start = np.negative(start_index.clip(max=0))
+            image_start = start_index + block_start
+        else:
+            block_start = np.zeros(len(block_size), dtype=int)
+            image_start = start_index
+
+        if not (image_size >= end_index).all():
+            block_crop = end_index - image_size
+            block_crop[block_crop < 0] = 0
+            block_end = pad_block_size - block_crop
+        else:
+            block_end = pad_block_size
+
+        end_index = start_index + block_end
+        block_read_idx = arrayutils.start_to_stop_idx(image_start, end_index)
+        block_write_idx = arrayutils.start_to_stop_idx(block_start, block_end)
+
+        block[block_write_idx] = self._file[key.to_path()][block_read_idx]
+        return block
+
+    def get_number_of_images(self, image_type: ImageType) -> int:
+        type_str = image_type.value
+        if type_str not in self._file:
+            return 0
+        return len(self._file[type_str])
+
+    def get_scales(self, image_type: ImageType) -> list[int]:
+        type_str = image_type.value
+        if type_str not in self._file:
+            return []
+
+        scales: list[int] = []
+        n_images = self.get_number_of_images(image_type)
+
+        for index in range(n_images):
+            group_path = f"{type_str}/{index}"
+            image_group = self._file[group_path]
+            group_scales: list[int] = []
+            for name in image_group:
+                if name.startswith("channel_"):
+                    group_scales.append(int(name.split("_")[-1]))
+
+            if index == 0:
+                scales = group_scales
+            elif set(scales) != set(group_scales):
+                raise ValueError(
+                    f"Database inconsistency: scales differ across images "
+                    f"for type {type_str}"
+                )
+
+        return scales
+
+    def check_if_exists(self, key: ImageKey) -> bool:
+        return key.to_path() in self._file
+
+    def delete_dataset(self, key: ImageKey) -> None:
+        path = key.to_path()
+        if path in self._file:
+            del self._file[path]
+
+    def close(self) -> None:
+        self._file.attrs["series_count"] = self._series_count
+        self._file.attrs["channel_count"] = self._channel_count
+        self._file.close()
+
+    def __enter__(self) -> "HDF5ImageStore":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/miplib/data/containers/image_data_store.py
+++ b/miplib/data/containers/image_data_store.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 
 
 class ImageType(StrEnum):
+    """Kind of image stored in the dataset."""
+
     ORIGINAL = "original"
     REGISTERED = "registered"
     FUSED = "fused"
@@ -22,12 +24,23 @@ class ImageType(StrEnum):
 
 @dataclass(frozen=True)
 class ImageKey:
+    """Unique identifier for an image dataset.
+
+    Parameters
+    ----------
+    image_type : The kind of image (original, registered, fused, psf).
+    index : View number (0-based).
+    channel : Color channel (0-based), default 0.
+    scale : Size as percentage of full resolution, default 100.
+    """
+
     image_type: ImageType
     index: int
     channel: int = 0
     scale: int = 100
 
     def to_path(self) -> str:
+        """Return the HDF5 path for this key."""
         if self.image_type == ImageType.FUSED:
             return f"fused/channel_{self.channel}_scale_{self.scale}"
         return (
@@ -143,6 +156,10 @@ class HDF5ImageStore:
     """HDF5-backed implementation of ImageDataStore."""
 
     def __init__(self, path: str) -> None:
+        """Open an HDF5 file at *path*, creating it if necessary.
+
+        The parent directory is created automatically.
+        """
         directory = os.path.dirname(path) or "."
         os.makedirs(directory, exist_ok=True)
 

--- a/miplib/data/containers/image_data_store.py
+++ b/miplib/data/containers/image_data_store.py
@@ -37,13 +37,21 @@ class ImageKey:
 
 
 class ImageDataStore(Protocol):
-    """Protocol defining the storage interface for multi-view image data."""
+    """Storage interface for multi-view image data.
+
+    Implementations must handle create/read/update/delete of image datasets,
+    attributes (spacing, angle, transforms), and scaled/blocks access.
+    """
 
     @property
-    def series_count(self) -> int: ...
+    def series_count(self) -> int:
+        """Number of distinct original image views (indices)."""
+        ...
 
     @property
-    def channel_count(self) -> int: ...
+    def channel_count(self) -> int:
+        """Number of color channels in the dataset."""
+        ...
 
     def add_image(
         self,
@@ -53,7 +61,12 @@ class ImageDataStore(Protocol):
         spacing: Sequence[float],
         chunk_size: tuple[int, ...] | None = None,
         calculated: bool | None = None,
-    ) -> None: ...
+    ) -> None:
+        """Store an image array with metadata.
+
+        No-op if the dataset already exists at the given key.
+        """
+        ...
 
     def add_fused_image(
         self,
@@ -61,7 +74,12 @@ class ImageDataStore(Protocol):
         scale: int,
         data: np.ndarray,
         spacing: Sequence[float],
-    ) -> None: ...
+    ) -> None:
+        """Store a fused (reconstructed) image.
+
+        Fused images are stored outside the per-view hierarchy.
+        """
+        ...
 
     def add_transform(
         self,
@@ -71,11 +89,17 @@ class ImageDataStore(Protocol):
         params: Sequence[float],
         fixed_params: Sequence[float],
         transform_type: int,
-    ) -> None: ...
+    ) -> None:
+        """Attach spatial transform parameters to a registered view."""
+        ...
 
-    def get_image_data(self, key: ImageKey) -> np.ndarray: ...
+    def get_image_data(self, key: ImageKey) -> np.ndarray:
+        """Read the raw image array at *key*."""
+        ...
 
-    def get_image_attributes(self, key: ImageKey) -> dict[str, Any]: ...
+    def get_image_attributes(self, key: ImageKey) -> dict[str, Any]:
+        """Read all metadata attributes (spacing, angle, size, transforms)."""
+        ...
 
     def get_registered_block(
         self,
@@ -83,17 +107,36 @@ class ImageDataStore(Protocol):
         block_size: np.ndarray,
         block_pad: int,
         block_start_index: np.ndarray,
-    ) -> np.ndarray: ...
+    ) -> np.ndarray:
+        """Read a padded sub-block of a registered image.
 
-    def get_number_of_images(self, image_type: ImageType) -> int: ...
+        Handles boundary conditions by zero-padding regions outside the
+        image extent.
+        """
+        ...
 
-    def get_scales(self, image_type: ImageType) -> list[int]: ...
+    def get_number_of_images(self, image_type: ImageType) -> int:
+        """Number of view indices present for *image_type*."""
+        ...
 
-    def check_if_exists(self, key: ImageKey) -> bool: ...
+    def get_scales(self, image_type: ImageType) -> list[int]:
+        """Available scale levels for *image_type*.
 
-    def delete_dataset(self, key: ImageKey) -> None: ...
+        Raises ``ValueError`` when scales are inconsistent across views.
+        """
+        ...
 
-    def close(self) -> None: ...
+    def check_if_exists(self, key: ImageKey) -> bool:
+        """Return ``True`` if the dataset at *key* exists."""
+        ...
+
+    def delete_dataset(self, key: ImageKey) -> None:
+        """Remove the dataset at *key*.  No-op if it does not exist."""
+        ...
+
+    def close(self) -> None:
+        """Persist file-level metadata and close the backing store."""
+        ...
 
 
 class HDF5ImageStore:

--- a/miplib/data/definitions.py
+++ b/miplib/data/definitions.py
@@ -15,5 +15,4 @@ itk_transforms_c = {
     "sitkBSplineTransform": 13,
 }
 
-image_types_c = ("original", "registered", "fused", "psf")
 params_c = ("angle", "scale", "index", "channel")

--- a/miplib/data/image_data_operations.py
+++ b/miplib/data/image_data_operations.py
@@ -19,6 +19,12 @@ def create_rescaled_images(
     scale: int,
     chunk_size: tuple[int, ...] | None = None,
 ) -> None:
+    """Downsample every image of *image_type* to *scale* percent of full size.
+
+    Reads the 100%-scale reference, zooms with cubic interpolation,
+    adjusts spacing, and writes the result.  Existing datasets at the
+    target scale are overwritten.
+    """
     existing_scales = store.get_scales(image_type)
     if scale in existing_scales and scale != 100:
         logger.info(
@@ -56,6 +62,11 @@ def create_rescaled_images(
 
 
 def calculate_missing_psfs(store: ImageDataStore) -> None:
+    """Synthesize missing PSFs by rotating the first PSF with per-view transforms.
+
+    For each registered view that lacks a PSF, the view 0 PSF is rotated
+    using the view's spatial transform and saved with ``calculated=True``.
+    """
     max_scale = max(store.get_scales(ImageType.REGISTERED))
     if max_scale < 100:
         logger.warning(
@@ -103,6 +114,11 @@ def copy_registration_result(
     from_scale: int,
     to_scale: int,
 ) -> None:
+    """Migrate registration transforms from one scale level to another.
+
+    Resamples original images at *to_scale* using the transforms stored
+    at *from_scale*, saving the results as registered images.
+    """
     if from_scale not in store.get_scales(ImageType.REGISTERED):
         raise ValueError(f"No registration result at scale {from_scale}")
 

--- a/miplib/data/image_data_operations.py
+++ b/miplib/data/image_data_operations.py
@@ -1,0 +1,166 @@
+import logging
+
+import numpy as np
+import scipy.ndimage as ndimage
+
+import miplib.processing.itk as itkutils
+from miplib.data.containers.image_data_store import (
+    ImageDataStore,
+    ImageKey,
+    ImageType,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def create_rescaled_images(
+    store: ImageDataStore,
+    image_type: ImageType,
+    scale: int,
+    chunk_size: tuple[int, ...] | None = None,
+) -> None:
+    existing_scales = store.get_scales(image_type)
+    if scale in existing_scales and scale != 100:
+        logger.info(
+            "Scale %i already exists for image type %s; overwriting.",
+            scale,
+            image_type,
+        )
+
+    z_factor = float(scale) / 100
+
+    n_images = store.get_number_of_images(image_type)
+    for index in range(n_images):
+        for channel in range(store.channel_count):
+            key_new = ImageKey(image_type, index, channel, scale)
+            key_ref = ImageKey(image_type, index, channel, 100)
+
+            if store.check_if_exists(key_new):
+                store.delete_dataset(key_new)
+
+            data_ref = store.get_image_data(key_ref)
+            attrs_ref = store.get_image_attributes(key_ref)
+
+            zoom = (z_factor,) * data_ref.ndim
+            data_scaled = ndimage.zoom(data_ref, zoom, order=3)
+
+            new_spacing = tuple(100 * x / scale for x in attrs_ref["spacing"])
+
+            store.add_image(
+                key_new,
+                data_scaled,
+                attrs_ref["angle"],
+                new_spacing,
+                chunk_size,
+            )
+
+
+def calculate_missing_psfs(store: ImageDataStore) -> None:
+    max_scale = max(store.get_scales(ImageType.REGISTERED))
+    if max_scale < 100:
+        logger.warning(
+            "No full-resolution registration available; using scale %i.",
+            max_scale,
+        )
+
+    for channel in range(store.channel_count):
+        key_psf_ref = ImageKey(ImageType.PSF, 0, channel, 100)
+        psf_data = store.get_image_data(key_psf_ref)
+        attrs_psf = store.get_image_attributes(key_psf_ref)
+        image_spacing = attrs_psf["spacing"]
+
+        n_registered = store.get_number_of_images(ImageType.REGISTERED)
+        for index in range(1, n_registered):
+            key_psf_new = ImageKey(ImageType.PSF, index, channel, 100)
+            if store.check_if_exists(key_psf_new):
+                continue
+
+            key_reg = ImageKey(ImageType.REGISTERED, index, channel, max_scale)
+            attrs_reg = store.get_image_attributes(key_reg)
+
+            transform = itkutils.make_itk_transform(
+                attrs_reg["tfm_type"],
+                psf_data.ndim,
+                attrs_reg["tfm_params"],
+                attrs_reg["tfm_fixed_params"],
+            )
+
+            psf_new = itkutils.rotate_psf(
+                psf_data, transform, image_spacing, return_numpy=True
+            )
+
+            store.add_image(
+                key_psf_new,
+                psf_new,
+                attrs_reg["angle"],
+                image_spacing,
+                calculated=True,
+            )
+
+
+def copy_registration_result(
+    store: ImageDataStore,
+    from_scale: int,
+    to_scale: int,
+) -> None:
+    if from_scale not in store.get_scales(ImageType.REGISTERED):
+        raise ValueError(f"No registration result at scale {from_scale}")
+
+    if to_scale not in store.get_scales(ImageType.ORIGINAL):
+        create_rescaled_images(store, ImageType.ORIGINAL, to_scale)
+
+    for channel in range(store.channel_count):
+        # View 0 is the reference: copy original to registered (identity).
+        key_orig0 = ImageKey(ImageType.ORIGINAL, 0, channel, to_scale)
+        data0 = store.get_image_data(key_orig0)
+        attrs0 = store.get_image_attributes(key_orig0)
+
+        key_reg0 = ImageKey(ImageType.REGISTERED, 0, channel, to_scale)
+        store.add_image(key_reg0, data0, 0, attrs0["spacing"])
+
+        # Get reference ITK image for resampling remaining views.
+        key_reg0_ref = ImageKey(ImageType.REGISTERED, 0, channel, to_scale)
+        reference = itkutils.convert_from_numpy(
+            store.get_image_data(key_reg0_ref),
+            store.get_image_attributes(key_reg0_ref)["spacing"],
+        )
+
+        n_original = store.get_number_of_images(ImageType.ORIGINAL)
+        for view in range(1, n_original):
+            key_reg_from = ImageKey(ImageType.REGISTERED, view, channel, from_scale)
+            attrs_reg_from = store.get_image_attributes(key_reg_from)
+
+            transform = itkutils.make_itk_transform(
+                attrs_reg_from["tfm_type"],
+                store.get_image_data(key_reg_from).ndim,
+                attrs_reg_from["tfm_params"],
+                attrs_reg_from["tfm_fixed_params"],
+            )
+
+            key_orig = ImageKey(ImageType.ORIGINAL, view, channel, to_scale)
+            itk_image = itkutils.convert_from_numpy(
+                store.get_image_data(key_orig),
+                store.get_image_attributes(key_orig)["spacing"],
+            )
+
+            resampled = itkutils.resample_image(
+                itk_image, transform, reference=reference
+            )
+            result = itkutils.convert_from_itk_image(resampled)
+
+            key_reg_new = ImageKey(ImageType.REGISTERED, view, channel, to_scale)
+            store.add_image(
+                key_reg_new,
+                np.asarray(result),
+                attrs_reg_from["angle"],
+                store.get_image_attributes(key_orig)["spacing"],
+            )
+
+            store.add_transform(
+                view,
+                channel,
+                to_scale,
+                attrs_reg_from["tfm_params"],
+                attrs_reg_from["tfm_fixed_params"],
+                attrs_reg_from["tfm_type"],
+            )

--- a/miplib/processing/fusion/fusion.py
+++ b/miplib/processing/fusion/fusion.py
@@ -32,6 +32,7 @@ import miplib.processing.ops_ext as ops_ext
 import miplib.processing.to_string as ops_output
 from miplib.data.containers import image_data
 from miplib.data.containers.image import Image
+from miplib.data.containers.image_data import ImageKey, ImageType
 from miplib.ui.progress import ProgressBar
 from miplib.utils.generic import isiterable
 
@@ -43,6 +44,11 @@ class MultiViewFusionRL:
     The Richardson-Lucy fusion is a result of simultaneous deblurring of
     several 3D volumes.
     """
+
+    def _reg_key(self, view):
+        return ImageKey(
+            ImageType.REGISTERED, view, self.options.channel, self.options.scale
+        )
 
     def __init__(self, data, writer, options):
         """
@@ -59,7 +65,7 @@ class MultiViewFusionRL:
 
         # Select views to fuse
         if self.options.fuse_views == -1:
-            self.views = range(self.data.get_number_of_images("registered"))
+            self.views = range(self.data.get_number_of_images(ImageType.REGISTERED))
         else:
             self.views = self.options.fuse_views
 
@@ -69,11 +75,7 @@ class MultiViewFusionRL:
         self.weights = np.zeros(self.n_views, dtype=np.float32)
 
         for idx, view in enumerate(self.views):
-            self.data.set_active_image(
-                view, self.options.channel, self.options.scale, "registered"
-            )
-
-            self.weights[idx] = self.data.get_max()
+            self.weights[idx] = self.data.get_max(self._reg_key(view))
 
         self.weights /= self.weights.sum()
 
@@ -84,7 +86,9 @@ class MultiViewFusionRL:
         elif isiterable(background):
             if len(background) == self.n_views:
                 self.background = np.asarray(background)
-            elif len(background) == self.data.get_number_of_images("registered"):
+            elif len(background) == self.data.get_number_of_images(
+                ImageType.REGISTERED
+            ):
                 self.background = np.asarray(background)[self.views]
             else:
                 raise ValueError("Invalid background definition length.")
@@ -92,15 +96,13 @@ class MultiViewFusionRL:
             self.background = np.zeros(self.n_views)
 
         # Get image size
-        self.data.set_active_image(
-            0, self.options.channel, self.options.scale, "registered"
-        )
-        self.image_size = self.data.get_image_size()
+        key0 = self._reg_key(0)
+        self.image_size = self.data.get_image_size(key0)
         self.imdims = len(self.image_size)
 
         print(f"The original image size is {tuple(self.image_size)}")
 
-        self.voxel_size = self.data.get_voxel_size()
+        self.voxel_size = self.data.get_voxel_size(key0)
         self.iteration_count = 0
 
         # Setup blocks
@@ -195,9 +197,7 @@ class MultiViewFusionRL:
             psf = self.psfs[idx]
             adj_psf = self.adj_psfs[idx]
 
-            self.data.set_active_image(
-                view, self.options.channel, self.options.scale, "registered"
-            )
+            reg_key = self._reg_key(view)
 
             weighting = self.weights[idx]
             background = self.background[idx]
@@ -231,7 +231,7 @@ class MultiViewFusionRL:
 
                 # Execute: cache = data/cache
                 image_block = self.data.get_registered_block(
-                    self.block_size, self.options.block_pad, index.copy()
+                    reg_key, self.block_size, self.options.block_pad, index.copy()
                 )
 
                 estimate_block_new = ops_array.safe_divide(
@@ -296,14 +296,12 @@ class MultiViewFusionRL:
 
         first_estimate = self.options.first_estimate
 
-        self.data.set_active_image(
-            0, self.options.channel, self.options.scale, "registered"
-        )
+        key0 = self._reg_key(0)
 
         if first_estimate == "first_image":
-            self.estimate[:] = self.data[:].astype(np.float32)
+            self.estimate[:] = self.data.get_image_data(key0).astype(np.float32)
         elif first_estimate == "first_image_mean":
-            self.estimate[:] = np.float32(np.mean(self.data[:]))
+            self.estimate[:] = np.float32(np.mean(self.data.get_image_data(key0)))
         elif first_estimate == "sum_of_originals":
             self.estimate[:] = fusion_utils.sum_of_all(
                 self.data, self.options.channel, self.options.scale
@@ -327,7 +325,7 @@ class MultiViewFusionRL:
 
         self.iteration_count = 0
         max_count = self.options.max_nof_iterations
-        initial_photon_count = self.data[:].sum()
+        initial_photon_count = self.data.get_image_data(key0).sum()
 
         bar = ProgressBar(0, max_count, total_width=40, show_percentage=False)
 
@@ -426,15 +424,13 @@ class MultiViewFusionRL:
         Reads the PSFs from the HDF5 data structure and zooms to the same pixel
         size with the registered images, of selected scale and channel.
         """
-        self.data.set_active_image(
-            0, self.options.channel, self.options.scale, "registered"
-        )
-        image_spacing = self.data.get_voxel_size()
+        reg_key0 = self._reg_key(0)
+        image_spacing = self.data.get_voxel_size(reg_key0)
 
         for i in self.views:
-            self.data.set_active_image(i, 0, 100, "psf")
-            psf_orig = self.data[:]
-            psf_spacing = self.data.get_voxel_size()
+            psf_key = ImageKey(ImageType.PSF, i, 0, 100)
+            psf_orig = self.data.get_image_data(psf_key)
+            psf_spacing = self.data.get_voxel_size(psf_key)
 
             # Zoom to the same voxel size
             zoom_factors = tuple(
@@ -623,14 +619,8 @@ class MultiViewFusionRL:
         return Image(self.estimate, self.voxel_size)
 
     def save_to_hdf(self):
-        """
-        Save result to the miplib data structure.
-
-        """
-        self.data.set_active_image(
-            0, self.options.channel, self.options.scale, "registered"
-        )
-        spacing = self.data.get_voxel_size()
+        """Save result to the miplib data structure."""
+        spacing = self.data.get_voxel_size(self._reg_key(0))
 
         self.data.add_fused_image(
             self.estimate, self.options.channel, self.options.scale, spacing

--- a/miplib/processing/fusion/fusion_cuda.py
+++ b/miplib/processing/fusion/fusion_cuda.py
@@ -72,9 +72,7 @@ class MultiViewFusionRLCuda(fusion.MultiViewFusionRL):
             psf_fft = self.psfs_fft[idx]
             adj_psf_fft = self.adj_psfs_fft[idx]
 
-            self.data.set_active_image(
-                view, self.options.channel, self.options.scale, "registered"
-            )
+            reg_key = self._reg_key(view)
 
             weighting = self.weights[idx]
             background = self.background[idx]
@@ -112,7 +110,7 @@ class MultiViewFusionRLCuda(fusion.MultiViewFusionRL):
 
                 # Divide image block with the convolution result
                 h_image_block = self.data.get_registered_block(
-                    self.block_size, self.options.block_pad, index.copy()
+                    reg_key, self.block_size, self.options.block_pad, index.copy()
                 ).astype(numpy.float32)
 
                 # h_estimate_block_new = ops_array.safe_divide(h_image_block, h_estimate_block_new)

--- a/miplib/processing/fusion/fusion_linear.py
+++ b/miplib/processing/fusion/fusion_linear.py
@@ -4,8 +4,19 @@ import miplib.processing.deconvolution.wiener_cuda as wiener
 from miplib.data.containers.image_data import ImageData, ImageKey, ImageType
 
 
-def wiener_fusion(data, options, gate=0, scale=100, views=None):
-    assert isinstance(data, ImageData)
+def wiener_fusion(
+    data: ImageData,
+    options,
+    gate: int = 0,
+    scale: int = 100,
+    views: list[int] | None = None,
+) -> np.ndarray:
+    """Fuse registered views by Wiener-deconvolving each with its PSF.
+
+    Returns the sum of individually deconvolved views.
+    """
+    if not isinstance(data, ImageData):
+        raise TypeError(f"Expected ImageData, got {type(data).__name__}")
 
     if views is None:
         views = list(range(data.get_number_of_images(ImageType.REGISTERED)))

--- a/miplib/processing/fusion/fusion_linear.py
+++ b/miplib/processing/fusion/fusion_linear.py
@@ -1,21 +1,22 @@
 import numpy as np
 
 import miplib.processing.deconvolution.wiener_cuda as wiener
-from miplib.data.containers.image_data import ImageData
+from miplib.data.containers.image_data import ImageData, ImageKey, ImageType
 
 
 def wiener_fusion(data, options, gate=0, scale=100, views=None):
     assert isinstance(data, ImageData)
 
     if views is None:
-        views = list(range(data.get_number_of_images("registered")))
+        views = list(range(data.get_number_of_images(ImageType.REGISTERED)))
 
-    result = np.zeros(data.get_image_size(), dtype=np.float32)
+    key0 = ImageKey(ImageType.REGISTERED, 0, gate, scale)
+    result = np.zeros(data.get_image_size(key0), dtype=np.float32)
     for idx in views:
-        data.set_active_image(idx, gate, scale, "registered")
-        image = data.get_image()
-        data.set_active_image(idx, gate, scale, "psf")
-        psf = data.get_image()
+        key_reg = ImageKey(ImageType.REGISTERED, idx, gate, scale)
+        image = data.get_image(key_reg)
+        key_psf = ImageKey(ImageType.PSF, idx, gate, scale)
+        psf = data.get_image(key_psf)
 
         result += wiener.wiener_deconvolution(
             image, psf, snr=options.wiener_snr, add_pad=options.block_pad

--- a/miplib/processing/fusion/utils.py
+++ b/miplib/processing/fusion/utils.py
@@ -1,49 +1,57 @@
 import numpy as np
 
 from miplib.data.containers.image import Image
-from miplib.data.containers.image_data import ImageData
+from miplib.data.containers.image_data import ImageData, ImageKey, ImageType
 
 
-def sum_of_all(data_structure, channel=0, scale=100, image_type="original"):
+def _to_imagetype(image_type: ImageType | str) -> ImageType:
+    if isinstance(image_type, ImageType):
+        return image_type
+    return ImageType(image_type)
+
+
+def sum_of_all(data_structure, channel=0, scale=100, image_type=ImageType.ORIGINAL):
     assert isinstance(data_structure, ImageData)
 
-    n_views = data_structure.get_number_of_images(image_type)
-    data_structure.set_active_image(0, channel, scale, image_type)
-    result = np.zeros(data_structure.get_image_size(), dtype=np.float32)
-    pixel_size = data_structure.get_voxel_size()
+    img_type = _to_imagetype(image_type)
+    n_views = data_structure.get_number_of_images(img_type)
+    key0 = ImageKey(img_type, 0, channel, scale)
+    result = np.zeros(data_structure.get_image_size(key0), dtype=np.float32)
+    pixel_size = data_structure.get_voxel_size(key0)
 
     for i in range(n_views):
-        data_structure.set_active_image(i, channel, scale, image_type)
-        result += data_structure[:]
+        key = ImageKey(img_type, i, channel, scale)
+        result += data_structure.get_image_data(key)
 
     return Image(result, pixel_size)
 
 
-def average_of_all(data_structure, channel=0, scale=100, image_type="original"):
+def average_of_all(data_structure, channel=0, scale=100, image_type=ImageType.ORIGINAL):
     assert isinstance(data_structure, ImageData)
-    n_views = data_structure.get_number_of_images(image_type)
-    data_structure.set_active_image(0, channel, scale, image_type)
-    pixel_size = data_structure.get_voxel_size()
+    img_type = _to_imagetype(image_type)
+    n_views = data_structure.get_number_of_images(img_type)
+    key0 = ImageKey(img_type, 0, channel, scale)
+    pixel_size = data_structure.get_voxel_size(key0)
 
-    result = sum_of_all(data_structure, channel, scale, image_type)
+    result = sum_of_all(data_structure, channel, scale, img_type)
 
     return Image(result / n_views, pixel_size)
 
 
 def simple_fusion(data_structure, channel=0, scale=100):
     assert isinstance(data_structure, ImageData)
-    image_type = "registered"
+    image_type = ImageType.REGISTERED
 
     n_views = data_structure.get_number_of_images(image_type)
-    data_structure.set_active_image(0, channel, scale, image_type)
-    pixel_size = data_structure.get_voxel_size()
+    key0 = ImageKey(image_type, 0, channel, scale)
+    pixel_size = data_structure.get_voxel_size(key0)
 
-    result = data_structure[:]
+    result = data_structure.get_image_data(key0)
 
     for i in range(1, n_views):
-        data_structure.set_active_image(i, channel, scale, image_type)
+        key = ImageKey(image_type, i, channel, scale)
         result = (
-            (result - (result - data_structure[:]).clip(min=0))
+            (result - (result - data_structure.get_image_data(key)).clip(min=0))
             .clip(min=0)
             .astype(np.float32)
         )

--- a/miplib/processing/fusion/utils.py
+++ b/miplib/processing/fusion/utils.py
@@ -10,8 +10,15 @@ def _to_imagetype(image_type: ImageType | str) -> ImageType:
     return ImageType(image_type)
 
 
-def sum_of_all(data_structure, channel=0, scale=100, image_type=ImageType.ORIGINAL):
-    assert isinstance(data_structure, ImageData)
+def sum_of_all(
+    data_structure: ImageData,
+    channel: int = 0,
+    scale: int = 100,
+    image_type: ImageType | str = ImageType.ORIGINAL,
+) -> Image:
+    """Sum all views of *image_type* into a single image."""
+    if not isinstance(data_structure, ImageData):
+        raise TypeError(f"Expected ImageData, got {type(data_structure).__name__}")
 
     img_type = _to_imagetype(image_type)
     n_views = data_structure.get_number_of_images(img_type)
@@ -26,8 +33,16 @@ def sum_of_all(data_structure, channel=0, scale=100, image_type=ImageType.ORIGIN
     return Image(result, pixel_size)
 
 
-def average_of_all(data_structure, channel=0, scale=100, image_type=ImageType.ORIGINAL):
-    assert isinstance(data_structure, ImageData)
+def average_of_all(
+    data_structure: ImageData,
+    channel: int = 0,
+    scale: int = 100,
+    image_type: ImageType | str = ImageType.ORIGINAL,
+) -> Image:
+    """Average all views of *image_type* into a single image."""
+    if not isinstance(data_structure, ImageData):
+        raise TypeError(f"Expected ImageData, got {type(data_structure).__name__}")
+
     img_type = _to_imagetype(image_type)
     n_views = data_structure.get_number_of_images(img_type)
     key0 = ImageKey(img_type, 0, channel, scale)
@@ -38,10 +53,16 @@ def average_of_all(data_structure, channel=0, scale=100, image_type=ImageType.OR
     return Image(result / n_views, pixel_size)
 
 
-def simple_fusion(data_structure, channel=0, scale=100):
-    assert isinstance(data_structure, ImageData)
-    image_type = ImageType.REGISTERED
+def simple_fusion(
+    data_structure: ImageData,
+    channel: int = 0,
+    scale: int = 100,
+) -> Image:
+    """Fuse registered views using a simple min-clip accumulation."""
+    if not isinstance(data_structure, ImageData):
+        raise TypeError(f"Expected ImageData, got {type(data_structure).__name__}")
 
+    image_type = ImageType.REGISTERED
     n_views = data_structure.get_number_of_images(image_type)
     key0 = ImageKey(image_type, 0, channel, scale)
     pixel_size = data_structure.get_voxel_size(key0)

--- a/miplib/processing/registration/registration_mv.py
+++ b/miplib/processing/registration/registration_mv.py
@@ -3,17 +3,13 @@ import SimpleITK as sitk
 
 import miplib.processing.itk as ops_itk
 from miplib.data.containers import image_data
+from miplib.data.containers.image_data import ImageKey, ImageType
 
 from . import registration
 
 
-# todo: This class has way too many responsibilities. Need to refactor at some point.
 class RotatedMultiViewRegistration:
-    """
-    A class for multiview image registration. The method is based on
-    functions inside the Insight Toolkit (www.itk.org), as in the original
-    *miplib*. In *miplib* SimpleITK was used instead of Python
-    wrapped ITK.
+    """Multi-view image registration using SimpleITK.
 
     The registration was updated to support multiple views
     and the new HDF5 data storage implementation. It was also implemented
@@ -54,9 +50,6 @@ class RotatedMultiViewRegistration:
             relaxationFactor=options.relaxation_factor,
             estimateLearningRate=self.registration.EachIteration,
         )
-        # translation_scale = 1.0 / options.translation_scale
-        # self.registration.SetOptimizerScales([10, 10, 10,
-        #                                       .1, .1,.1])
 
         self.registration.SetOptimizerScalesFromJacobian()
 
@@ -80,24 +73,19 @@ class RotatedMultiViewRegistration:
         self.registration.SetMetricSamplingStrategy(self.registration.RANDOM)
         self.registration.SetMetricSamplingPercentage(options.sampling_percentage)
 
+    def _orig_key(self, index):
+        return ImageKey(
+            ImageType.ORIGINAL, index, self.options.channel, self.options.scale
+        )
+
     def execute(self):
-        """
-        Run image registration. All the views are registered one by one. The
-        image
-        at index 0 is used as a reference.
-        """
+        """Run image registration. All views registered against index 0."""
 
         # Get reference image.
-        self.data.set_active_image(
-            self.fixed_index, self.options.channel, self.options.scale, "original"
-        )
-        fixed_image = self.data.get_itk_image()
+        fixed_image = self.data.get_itk_image(self._orig_key(self.fixed_index))
 
         # Get moving image
-        self.data.set_active_image(
-            self.moving_index, self.options.channel, self.options.scale, "original"
-        )
-        moving_image = self.data.get_itk_image()
+        moving_image = self.data.get_itk_image(self._orig_key(self.moving_index))
 
         # INITIALIZATION
         # --------------
@@ -112,7 +100,9 @@ class RotatedMultiViewRegistration:
         manual_transform.SetCenter(rotation_center)
 
         # Rotation
-        initial_rotation = self.data.get_rotation_angle(radians=True)
+        initial_rotation = self.data.get_rotation_angle(
+            self._orig_key(self.moving_index), radians=True
+        )
         if self.options.rot_axis == 0:
             manual_transform.SetRotation(initial_rotation, 0, 0)
         elif self.options.rot_axis == 1:
@@ -136,17 +126,10 @@ class RotatedMultiViewRegistration:
             sitk.CenteredTransformInitializerFilter.MOMENTS,
         )
 
-        # print "The initial transform is:"
-        # print transform
-
         # Set initial transform
         self.registration.SetInitialTransform(transform)
 
         # SPATIAL MASK
-        # =====================================================================
-        # The registration metric works more reliably when it knows where
-        # non-zero
-        # voxels are located.
         thd = self.options.mask_threshold
         fixed_mask = sitk.BinaryDilate(sitk.BinaryThreshold(fixed_image, 0, thd, 0, 1))
         moving_mask = sitk.BinaryDilate(
@@ -180,12 +163,6 @@ class RotatedMultiViewRegistration:
         result = sitk.AffineTransform(result)
         # RESULTS
         # =====================================================================
-        # Combine two partial transforms into one.
-        # self.final_transform = sitk.Transform(manual_transform)
-        # self.final_transform.AddTransform(result)
-
-        # The two resulting transforms are combined into one here, because
-        # it is easier to save a single transform into a HDF5 file.
 
         A0 = numpy.asarray(manual_transform.GetMatrix()).reshape(3, 3)
         c0 = numpy.asarray(manual_transform.GetCenter())
@@ -249,17 +226,9 @@ class RotatedMultiViewRegistration:
         Get the registration result as a resampled image.
         """
 
-        self.data.set_active_image(
-            self.fixed_index, self.options.channel, self.options.scale, "original"
-        )
+        fixed_image = self.data.get_itk_image(self._orig_key(self.fixed_index))
 
-        fixed_image = self.data.get_itk_image()
-
-        self.data.set_active_image(
-            self.moving_index, self.options.channel, self.options.scale, "original"
-        )
-
-        moving_image = self.data.get_itk_image()
+        moving_image = self.data.get_itk_image(self._orig_key(self.moving_index))
 
         return ops_itk.resample_image(moving_image, self.final_transform, fixed_image)
 
@@ -268,10 +237,9 @@ class RotatedMultiViewRegistration:
         channel = self.options.channel
         view = self.moving_index
 
-        # Add registered image
-        self.data.set_active_image(view, channel, scale, "original")
-        angle = self.data.get_rotation_angle(radians=False)
-        spacing = self.data.get_voxel_size()
+        key = self._orig_key(view)
+        angle = self.data.get_rotation_angle(key, radians=False)
+        spacing = self.data.get_voxel_size(key)
         registered_image = ops_itk.convert_from_itk_image(self.get_resampled_result())
         self.data.add_registered_image(
             registered_image, scale, view, channel, angle, spacing
@@ -304,20 +272,13 @@ class RotatedMultiViewRegistration:
 class MultiViewRegistrationISM(RotatedMultiViewRegistration):
     def execute(self):
         # Get reference image.
-        self.data.set_active_image(
-            self.fixed_index, self.options.channel, self.options.scale, "original"
-        )
-        fixed_image = self.data.get_itk_image()
+        fixed_image = self.data.get_itk_image(self._orig_key(self.fixed_index))
 
-        for idx in range(self.data.get_number_of_images("original")):
+        for idx in range(self.data.get_number_of_images(ImageType.ORIGINAL)):
             print(f"Registering view {idx}")
             self.moving_index = idx
 
-            # Get moving image
-            self.data.set_active_image(
-                self.moving_index, self.options.channel, self.options.scale, "original"
-            )
-            moving_image = self.data.get_itk_image()
+            moving_image = self.data.get_itk_image(self._orig_key(self.moving_index))
 
             # Register
             if moving_image.GetDimension() == 2:

--- a/tests/data/containers/test_image_data.py
+++ b/tests/data/containers/test_image_data.py
@@ -1,0 +1,608 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from miplib.data.containers.image import Image
+from miplib.data.containers.image_data import ImageData, ImageKey, ImageType
+from miplib.data.containers.image_data_store import HDF5ImageStore
+
+# --- ImageType ----------------------------------------------------------------
+
+
+def test_image_type_is_strenum():
+    assert isinstance(ImageType.ORIGINAL, str)
+    assert ImageType.ORIGINAL == "original"
+    assert ImageType("registered") == ImageType.REGISTERED
+    assert list(ImageType) == [
+        ImageType.ORIGINAL,
+        ImageType.REGISTERED,
+        ImageType.FUSED,
+        ImageType.PSF,
+    ]
+
+
+# --- ImageKey -----------------------------------------------------------------
+
+
+def test_image_key_to_path_original():
+    key = ImageKey(ImageType.ORIGINAL, 0, 0, 100)
+    assert key.to_path() == "original/0/channel_0_scale_100"
+
+
+def test_image_key_to_path_fused():
+    key = ImageKey(ImageType.FUSED, 0, 0, 100)
+    assert key.to_path() == "fused/channel_0_scale_100"
+
+
+def test_image_key_to_path_multichannel():
+    key = ImageKey(ImageType.REGISTERED, 2, 1, 50)
+    assert key.to_path() == "registered/2/channel_1_scale_50"
+
+
+def test_image_key_frozen():
+    with pytest.raises(Exception):
+        key = ImageKey(ImageType.ORIGINAL, 0)
+        key.index = 1  # type: ignore[misc]
+
+
+def test_image_key_defaults():
+    key = ImageKey(ImageType.PSF, index=0)
+    assert key.channel == 0
+    assert key.scale == 100
+
+
+# --- HDF5ImageStore -----------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path):
+    path = str(tmp_path / "test.hdf5")
+    s = HDF5ImageStore(path)
+    yield s
+    s.close()
+
+
+def test_store_initial_state(store):
+    assert store.series_count == 0
+    assert store.channel_count == 1
+
+
+def test_add_and_get_image_data(store):
+    data = np.arange(27, dtype=np.float32).reshape(3, 3, 3)
+    key = ImageKey(ImageType.ORIGINAL, 0, 0, 100)
+    store.add_image(key, data, angle=45.0, spacing=[0.1, 0.1, 0.1])
+
+    assert store.check_if_exists(key)
+    npt.assert_array_equal(store.get_image_data(key), data)
+
+
+def test_add_image_stores_attributes(store):
+    data = np.ones((4, 4), dtype=np.float64)
+    key = ImageKey(ImageType.REGISTERED, 1, 0, 50)
+    store.add_image(key, data, angle=90.0, spacing=[0.2, 0.2])
+
+    attrs = store.get_image_attributes(key)
+    assert attrs["angle"] == 90.0
+    assert attrs["spacing"] == [0.2, 0.2]
+    assert list(attrs["size"]) == [4, 4]
+
+
+def test_add_psf_with_calculated_flag(store):
+    data = np.ones((2, 2), dtype=np.float32)
+    key = ImageKey(ImageType.PSF, 0, 0, 100)
+    store.add_image(key, data, angle=0.0, spacing=[1.0, 1.0], calculated=True)
+
+    attrs = store.get_image_attributes(key)
+    assert attrs["calculated"] is True
+
+
+def test_add_image_increments_series_count(store):
+    assert store.series_count == 0
+    store.add_image(
+        ImageKey(ImageType.ORIGINAL, 0, 0, 100),
+        np.ones((2, 2)),
+        angle=0.0,
+        spacing=[1.0, 1.0],
+    )
+    assert store.series_count == 1
+
+
+def test_add_image_duplicate_index_no_increment(store):
+    store.add_image(
+        ImageKey(ImageType.ORIGINAL, 0, 0, 100),
+        np.ones((2, 2)),
+        angle=0.0,
+        spacing=[1.0, 1.0],
+    )
+    store.add_image(
+        ImageKey(ImageType.ORIGINAL, 0, 0, 50),
+        np.ones((1, 1)),
+        angle=0.0,
+        spacing=[1.0, 1.0],
+    )
+    assert store.series_count == 1
+
+
+def test_add_image_no_double_add(store):
+    data = np.ones((2, 2))
+    key = ImageKey(ImageType.ORIGINAL, 0, 0, 100)
+    store.add_image(key, data, angle=0.0, spacing=[1.0, 1.0])
+
+    data2 = np.zeros((2, 2))
+    store.add_image(key, data2, angle=1.0, spacing=[2.0, 2.0])
+
+    npt.assert_array_equal(store.get_image_data(key), data)
+    assert store.get_image_attributes(key)["angle"] == 0.0
+
+
+def test_add_image_rejects_non_ndarray(store):
+    with pytest.raises(TypeError, match="Expected numpy.ndarray"):
+        store.add_image(
+            ImageKey(ImageType.ORIGINAL, 0, 0, 100),
+            [1, 2, 3],  # type: ignore[arg-type]
+            angle=0.0,
+            spacing=[1.0],
+        )
+
+
+def test_add_fused_image(store):
+    data = np.ones((5, 5), dtype=np.float32)
+    store.add_fused_image(channel=0, scale=100, data=data, spacing=[0.5, 0.5])
+
+    key = ImageKey(ImageType.FUSED, 0, 0, 100)
+    assert store.check_if_exists(key)
+    npt.assert_array_equal(store.get_image_data(key), data)
+
+
+def test_add_fused_image_no_duplicate(store):
+    data = np.ones((2, 2))
+    store.add_fused_image(channel=0, scale=100, data=data, spacing=[1.0, 1.0])
+    store.add_fused_image(
+        channel=0, scale=100, data=np.zeros((2, 2)), spacing=[2.0, 2.0]
+    )
+    assert store.get_image_attributes(ImageKey(ImageType.FUSED, 0, 0, 100))[
+        "spacing"
+    ] == [1.0, 1.0]
+
+
+def test_add_transform(store):
+    data = np.ones((4, 4))
+    key = ImageKey(ImageType.REGISTERED, 0, 0, 100)
+    store.add_image(key, data, angle=0.0, spacing=[1.0, 1.0])
+    store.add_transform(
+        index=0,
+        channel=0,
+        scale=100,
+        params=[1.0, 2.0, 3.0],
+        fixed_params=[0.0],
+        transform_type=10,
+    )
+
+    attrs = store.get_image_attributes(key)
+    assert attrs["tfm_type"] == 10
+    assert attrs["tfm_params"] == [1.0, 2.0, 3.0]
+    assert attrs["tfm_fixed_params"] == [0.0]
+
+
+def test_add_transform_missing_dataset_raises(store):
+    with pytest.raises(ValueError, match="does not exist"):
+        store.add_transform(
+            index=0,
+            channel=0,
+            scale=100,
+            params=[1.0],
+            fixed_params=[0.0],
+            transform_type=10,
+        )
+
+
+def test_get_number_of_images(store):
+    assert store.get_number_of_images(ImageType.ORIGINAL) == 0
+
+    store.add_image(
+        ImageKey(ImageType.ORIGINAL, 0, 0, 100),
+        np.ones((2, 2)),
+        angle=0.0,
+        spacing=[1.0, 1.0],
+    )
+    store.add_image(
+        ImageKey(ImageType.ORIGINAL, 1, 0, 100),
+        np.ones((2, 2)),
+        angle=0.0,
+        spacing=[1.0, 1.0],
+    )
+
+    assert store.get_number_of_images(ImageType.ORIGINAL) == 2
+    assert store.get_number_of_images(ImageType.REGISTERED) == 0
+
+
+def test_get_scales_consistent(store):
+    store.add_image(
+        ImageKey(ImageType.ORIGINAL, 0, 0, 100),
+        np.ones((3, 3)),
+        angle=0.0,
+        spacing=[1.0, 1.0],
+    )
+    store.add_image(
+        ImageKey(ImageType.ORIGINAL, 0, 0, 50),
+        np.ones((1, 1)),
+        angle=0.0,
+        spacing=[2.0, 2.0],
+    )
+    store.add_image(
+        ImageKey(ImageType.ORIGINAL, 1, 0, 100),
+        np.ones((3, 3)),
+        angle=0.0,
+        spacing=[1.0, 1.0],
+    )
+    store.add_image(
+        ImageKey(ImageType.ORIGINAL, 1, 0, 50),
+        np.ones((1, 1)),
+        angle=0.0,
+        spacing=[2.0, 2.0],
+    )
+
+    scales = store.get_scales(ImageType.ORIGINAL)
+    assert set(scales) == {50, 100}
+
+
+def test_get_scales_inconsistent_raises(store):
+    store.add_image(
+        ImageKey(ImageType.ORIGINAL, 0, 0, 100),
+        np.ones((3, 3)),
+        angle=0.0,
+        spacing=[1.0, 1.0],
+    )
+    store.add_image(
+        ImageKey(ImageType.ORIGINAL, 1, 0, 50),
+        np.ones((1, 1)),
+        angle=0.0,
+        spacing=[2.0, 2.0],
+    )
+
+    with pytest.raises(ValueError, match="inconsisten"):
+        store.get_scales(ImageType.ORIGINAL)
+
+
+def test_check_if_exists(store):
+    key = ImageKey(ImageType.ORIGINAL, 0, 0, 100)
+    assert not store.check_if_exists(key)
+
+    store.add_image(key, np.ones((2, 2)), angle=0.0, spacing=[1.0, 1.0])
+    assert store.check_if_exists(key)
+
+
+def test_delete_dataset(store):
+    key = ImageKey(ImageType.ORIGINAL, 0, 0, 100)
+    store.add_image(key, np.ones((2, 2)), angle=0.0, spacing=[1.0, 1.0])
+    assert store.check_if_exists(key)
+
+    store.delete_dataset(key)
+    assert not store.check_if_exists(key)
+
+
+def test_delete_nonexistent_is_silent(store):
+    key = ImageKey(ImageType.ORIGINAL, 0, 0, 100)
+    store.delete_dataset(key)  # no error
+
+
+def test_registered_block_full_read(store):
+    data = np.arange(64, dtype=np.float32).reshape(4, 4, 4)
+    key = ImageKey(ImageType.REGISTERED, 0, 0, 100)
+    store.add_image(key, data, angle=0.0, spacing=[1.0, 1.0, 1.0])
+
+    block = store.get_registered_block(
+        key,
+        block_size=np.array([4, 4, 4]),
+        block_pad=0,
+        block_start_index=np.array([0, 0, 0]),
+    )
+    npt.assert_array_equal(block, data)
+
+
+def test_registered_block_with_padding(store):
+    data = np.ones((4, 4), dtype=np.float32)
+    key = ImageKey(ImageType.REGISTERED, 0, 0, 100)
+    store.add_image(key, data, angle=0.0, spacing=[1.0, 1.0])
+
+    block = store.get_registered_block(
+        key,
+        block_size=np.array([2, 2]),
+        block_pad=1,
+        block_start_index=np.array([0, 0]),
+    )
+    assert block.shape == (4, 4)
+
+
+def test_registered_block_boundary_handling(store):
+    data = np.ones((3, 3), dtype=np.float32)
+    key = ImageKey(ImageType.REGISTERED, 0, 0, 100)
+    store.add_image(key, data, angle=0.0, spacing=[1.0, 1.0])
+
+    block = store.get_registered_block(
+        key,
+        block_size=np.array([2, 2]),
+        block_pad=1,
+        block_start_index=np.array([2, 2]),
+    )
+    assert block.shape == (4, 4)
+
+
+def test_registered_block_non_registered_raises(store):
+    data = np.ones((2, 2))
+    key = ImageKey(ImageType.ORIGINAL, 0, 0, 100)
+    store.add_image(key, data, angle=0.0, spacing=[1.0, 1.0])
+
+    with pytest.raises(ValueError, match="REGISTERED"):
+        store.get_registered_block(
+            key,
+            block_size=np.array([2, 2]),
+            block_pad=0,
+            block_start_index=np.array([0, 0]),
+        )
+
+
+def test_context_manager(tmp_path):
+    path = str(tmp_path / "ctx.hdf5")
+    with HDF5ImageStore(path) as s:
+        s.add_image(
+            ImageKey(ImageType.ORIGINAL, 0, 0, 100),
+            np.ones((2, 2)),
+            angle=0.0,
+            spacing=[1.0, 1.0],
+        )
+    # File closed; reopening should work
+    s2 = HDF5ImageStore(path)
+    assert s2.series_count == 1
+    s2.close()
+
+
+def test_reopen_preserves_data(tmp_path):
+    path = str(tmp_path / "reopen.hdf5")
+    s1 = HDF5ImageStore(path)
+    s1.add_image(
+        ImageKey(ImageType.ORIGINAL, 0, 0, 100),
+        np.ones((3, 3)),
+        angle=30.0,
+        spacing=[0.5, 0.5],
+    )
+    s1.close()
+
+    s2 = HDF5ImageStore(path)
+    key = ImageKey(ImageType.ORIGINAL, 0, 0, 100)
+    assert s2.check_if_exists(key)
+    assert s2.get_image_attributes(key)["angle"] == 30.0
+    s2.close()
+
+
+# --- ImageData facade ---------------------------------------------------------
+
+
+@pytest.fixture
+def imagedata(tmp_path):
+    path = str(tmp_path / "imdata.hdf5")
+    data = ImageData(path)
+    yield data
+    data.close()
+
+
+def test_facade_add_original(imagedata):
+    imagedata.add_original_image(
+        np.ones((3, 3), dtype=np.float32),
+        scale=100,
+        index=0,
+        channel=0,
+        angle=30.0,
+        spacing=[1.0, 1.0],
+    )
+    key = ImageKey(ImageType.ORIGINAL, 0, 0, 100)
+    assert imagedata.check_if_exists(ImageType.ORIGINAL, 0, 0, 100)
+    m = imagedata.get_max(key)
+    assert m == 1.0
+
+
+def test_facade_add_original_anisotropic_resample(imagedata):
+    data = np.ones((10, 16, 16), dtype=np.float32)
+    imagedata.add_original_image(
+        data,
+        scale=100,
+        index=0,
+        channel=0,
+        angle=0.0,
+        spacing=[2.0, 1.0, 1.0],
+    )
+    key = ImageKey(ImageType.ORIGINAL, 0, 0, 100)
+    img = imagedata.get_image(key)
+    assert img.shape[0] == 20  # z-zoom: 2.0 / 1.0 = 2x
+
+
+def test_facade_add_registered_overwrite(imagedata):
+    key = ImageKey(ImageType.REGISTERED, 0, 0, 100)
+    imagedata.add_registered_image(
+        np.ones((3, 3)),
+        scale=100,
+        index=0,
+        channel=0,
+        angle=0.0,
+        spacing=[1.0, 1.0],
+    )
+    imagedata.add_registered_image(
+        np.zeros((3, 3)),
+        scale=100,
+        index=0,
+        channel=0,
+        angle=90.0,
+        spacing=[1.0, 1.0],
+        overwrite=False,
+    )
+    assert imagedata.get_max(key) == 1.0
+
+    imagedata.add_registered_image(
+        np.zeros((3, 3)),
+        scale=100,
+        index=0,
+        channel=0,
+        angle=90.0,
+        spacing=[1.0, 1.0],
+        overwrite=True,
+    )
+    assert imagedata.get_max(key) == 0.0
+
+
+def test_facade_get_voxel_size(imagedata):
+    imagedata.add_original_image(
+        np.ones((2, 3, 3)),
+        scale=100,
+        index=0,
+        channel=0,
+        angle=0.0,
+        spacing=[2.0, 1.0, 1.0],
+    )
+    key = ImageKey(ImageType.ORIGINAL, 0, 0, 100)
+    vs = imagedata.get_voxel_size(key)
+    assert vs == [1.0, 1.0, 1.0]  # after isotropic resampling
+
+
+def test_facade_get_rotation_angle(imagedata):
+    imagedata.add_original_image(
+        np.ones((3, 3)),
+        scale=100,
+        index=0,
+        channel=0,
+        angle=90.0,
+        spacing=[1.0, 1.0],
+    )
+    key = ImageKey(ImageType.ORIGINAL, 0, 0, 100)
+    rads = imagedata.get_rotation_angle(key, radians=True)
+    assert np.isclose(rads, np.pi / 2.0)
+    degs = imagedata.get_rotation_angle(key, radians=False)
+    assert degs == 90.0
+
+
+def test_facade_get_image(imagedata):
+    data = np.ones((4, 4), dtype=np.float32)
+    imagedata.add_original_image(
+        data,
+        scale=100,
+        index=0,
+        channel=0,
+        angle=0.0,
+        spacing=[0.5, 0.5],
+    )
+    key = ImageKey(ImageType.ORIGINAL, 0, 0, 100)
+    img = imagedata.get_image(key)
+    assert isinstance(img, Image)
+    assert img.spacing == [0.5, 0.5]
+
+
+def test_facade_get_image_size(imagedata):
+    imagedata.add_original_image(
+        np.ones((4, 8, 16)),
+        scale=100,
+        index=0,
+        channel=0,
+        angle=0.0,
+        spacing=[1.0, 1.0, 1.0],
+    )
+    key = ImageKey(ImageType.ORIGINAL, 0, 0, 100)
+    assert imagedata.get_image_size(key) == (4, 8, 16)
+
+
+def test_facade_get_dtype(imagedata):
+    imagedata.add_original_image(
+        np.ones((2, 2), dtype=np.int32),
+        scale=100,
+        index=0,
+        channel=0,
+        angle=0.0,
+        spacing=[1.0, 1.0],
+    )
+    key = ImageKey(ImageType.ORIGINAL, 0, 0, 100)
+    assert imagedata.get_dtype(key) == np.int32
+
+
+def test_facade_get_number_of_images(imagedata):
+    imagedata.add_original_image(
+        np.ones((2, 2)),
+        scale=100,
+        index=0,
+        channel=0,
+        angle=0.0,
+        spacing=[1.0, 1.0],
+    )
+    imagedata.add_original_image(
+        np.ones((2, 2)),
+        scale=100,
+        index=1,
+        channel=0,
+        angle=0.0,
+        spacing=[1.0, 1.0],
+    )
+    assert imagedata.get_number_of_images(ImageType.ORIGINAL) == 2
+
+
+def test_facade_get_scales(imagedata):
+    imagedata.add_original_image(
+        np.ones((4, 4)),
+        scale=100,
+        index=0,
+        channel=0,
+        angle=0.0,
+        spacing=[1.0, 1.0],
+    )
+    imagedata.add_original_image(
+        np.ones((2, 2)),
+        scale=50,
+        index=0,
+        channel=0,
+        angle=0.0,
+        spacing=[2.0, 2.0],
+    )
+    scales = imagedata.get_scales(ImageType.ORIGINAL)
+    assert set(scales) == {50, 100}
+
+
+def test_facade_add_fused(imagedata):
+    data = np.ones((5, 5))
+    imagedata.add_fused_image(data, channel=0, scale=100, spacing=[0.3, 0.3])
+    key = ImageKey(ImageType.FUSED, 0, 0, 100)
+    npt.assert_array_equal(imagedata.get_image_data(key), data)
+
+
+def test_facade_series_and_channel_count(imagedata):
+    assert imagedata.channel_count == 1
+    assert imagedata.series_count == 0
+    imagedata.add_original_image(
+        np.ones((2, 2)),
+        scale=100,
+        index=0,
+        channel=0,
+        angle=0.0,
+        spacing=[1.0, 1.0],
+    )
+    assert imagedata.series_count == 1
+
+
+def test_facade_add_original_rejects_non_ndarray(imagedata):
+    with pytest.raises(TypeError, match="Expected numpy.ndarray"):
+        imagedata.add_original_image(
+            [1, 2, 3],  # type: ignore[arg-type]
+            scale=100,
+            index=0,
+            channel=0,
+            angle=0.0,
+            spacing=[1.0],
+        )
+
+
+def test_facade_can_accept_string_image_type(imagedata):
+    imagedata.add_original_image(
+        np.ones((2, 2)),
+        scale=100,
+        index=0,
+        channel=0,
+        angle=0.0,
+        spacing=[1.0, 1.0],
+    )
+    assert imagedata.get_number_of_images("original") == 1
+    assert imagedata.get_scales("original") == [100]


### PR DESCRIPTION
## Summary

Refactors the 774-line `ImageData` class into a composable architecture:

### New

- **`ImageType`** (StrEnum) — type-safe replacement for `image_types_c`
- **`ImageKey`** (frozen dataclass) — bundles (image_type, index, channel, scale) into one parameter
- **`ImageDataStore`** (Protocol) — storage interface for multi-view image data
- **`HDF5ImageStore`** — HDF5 implementation of the protocol
- **`image_data_operations.py`** — standalone functions for `create_rescaled_images`, `calculate_missing_psfs`, `copy_registration_result`

### Changed

- **`ImageData`** — now a thin facade (~180 lines, down from 774) composing `HDF5ImageStore`. All getters take explicit `ImageKey`. Removed: `active_image`, `set_active_image`, `__getitem__`, `__setitem__`, `print()`, `uiutils.get_user_input` from data layer.
- **8 consumer files** updated to use `ImageKey`-based API
- **`definitions.py`** — removed `image_types_c`

### API before/after

```python
# Before: 2-step stateful
data.set_active_image(view, ch, sc, "registered")
val = data.get_max()

# After: 1-step stateless with reusable key
key = ImageKey(ImageType.REGISTERED, view, ch, sc)
val = data.get_max(key)
```

### Tests

- 44 new tests for store, protocol, facade, path construction, edge cases
- 339 total passing (295 original + 44 new)
- Ruff + mypy clean