### PR TITLE
Refactor iterators (compose SimplePolarIndexer), fix I/O bugs, add 48 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
       - uses: astral-sh/setup-uv@v5
       - run: uv sync --frozen --group dev
       - run: uv run pytest tests/

--- a/miplib/analysis/image_quality/filters.py
+++ b/miplib/analysis/image_quality/filters.py
@@ -225,9 +225,9 @@ class FrequencyQuality(Filter):
 
         average = np.zeros(iterator.nbins)
 
-        for idx, ring in enumerate(iterator):
-            subset = self.power[ring]
-            average[idx] = float(subset.sum()) / subset.size
+        for ring_indices, ring_idx in iterator:
+            subset = self.power[ring_indices]
+            average[ring_idx] = float(subset.sum()) / subset.size
 
         # TODO: This hand-rolls physical-frequency-axis scaling; candidate
         # to refactor onto generate_polar_coordinate_grid

--- a/miplib/bin/pyimq.py
+++ b/miplib/bin/pyimq.py
@@ -161,7 +161,7 @@ def main():
                     continue
                 # ImageJ files have particular TIFF tags that can be processed correctly
                 # with the options.imagej switch
-                image = read.get_image(path, channel=options.rgb_channel)
+                image = read.get_image(real_path, channel=options.rgb_channel)
 
                 # Only grayscale images are processed. If the input is an RGB image,
                 # a channel can be chosen for processing.

--- a/miplib/data/coordinates/polar.py
+++ b/miplib/data/coordinates/polar.py
@@ -24,8 +24,8 @@ class SimplePolarIndexer:
             raise ValueError(f"shape must be 2D or 3D, got {len(shape)}-dimensional")
 
         axes = tuple(np.arange(-np.floor(s / 2.0), np.ceil(s / 2.0)) for s in shape)
-        meshgrid = np.meshgrid(*axes)
-        self.r = np.sqrt(sum(axis**2 for axis in meshgrid))
+        self.meshgrid = np.meshgrid(*axes)
+        self.r = np.sqrt(sum(axis**2 for axis in self.meshgrid))
 
     def __getitem__(self, item: float) -> np.ndarray:
         return self.r == item

--- a/miplib/data/io/array_detector_data.py
+++ b/miplib/data/io/array_detector_data.py
@@ -110,7 +110,7 @@ def read_tiff_sequence(path, detectors=25, channels=1):
     data = ArrayDetectorData(detectors, channels)
     steps = itertools.product(range(channels), range(detectors))
     for idx, (channel, detector) in enumerate(steps):
-        image = imread.get_image(os.path.join(path, files[idx]), bioformats=False)
+        image = imread.get_image(os.path.join(path, files[idx]))
         data[detector, channel] = image
 
     return data

--- a/miplib/data/io/fourier_correlation_data_reader.py
+++ b/miplib/data/io/fourier_correlation_data_reader.py
@@ -10,45 +10,27 @@ from miplib.data.containers.image import Image
 
 
 class FourierCorrelationDataReader:
-    """A class for reading Fourier Correlation Data from an HDF5 file."""
+    """Read Fourier Correlation Data from an HDF5 file."""
 
-    # region Constructor and Destructor
-    def __init__(self, file_path):
-        # Create output dir, if it doesn't exist output dir if
+    def __init__(self, file_path: str) -> None:
         if not os.path.isfile(file_path) or not file_path.endswith(".hdf5"):
             raise ValueError(f"Not a valid filename: {file_path}")
 
         self.data = h5py.File(file_path, mode="r")
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.close()
 
-    # endregion
-
-    def read_metadata(self):
-        """
-        Read a metadata dictionary from the HDF5 files header
-        """
+    def read_metadata(self) -> dict[str, object]:
+        """Read a metadata dictionary from the HDF5 file header."""
         return dict(self.data.attrs)
 
-    def read_images(self, index=None):
-        """
-        Read images from the data structure.
-        :returns images: a tuple of Image objects, or a single image
-        """
-
+    def read_images(self) -> list[Image]:
+        """Read images from the data structure."""
         if "images" not in self.data:
             raise ValueError("No images to read")
 
-        if index is not None:
-            image_name = f"image_{index}"
-            ds = self.data["images"][image_name]
-            spacing = [
-                float(s) for s in ds.attrs["pixel_size"].split()[0 : len(ds.shape)]
-            ]
-            return Image(ds[:], spacing)
-
-        images = []
+        images: list[Image] = []
         for name in self.data["images"]:
             ds = self.data["images"][name]
             spacing = [
@@ -58,12 +40,8 @@ class FourierCorrelationDataReader:
 
         return images
 
-    def read_data_set(self):
-        """
-        Read Fourier Correlation Data file (FRC, FSC etc) to the FourierCorrelationDataCollection
-        data structure.
-        :returns FourierCorrelationDataCollection
-        """
+    def read_data_set(self) -> FourierCorrelationDataCollection:
+        """Read FRC/FSC data into a FourierCorrelationDataCollection."""
         group_prefix = "data_set_"
         data_sets = FourierCorrelationDataCollection()
         for group_name in list(self.data.keys()):
@@ -99,9 +77,6 @@ class FourierCorrelationDataReader:
 
         return data_sets
 
-    def close(self):
-        """
-        A function to explicitly close the data file (will be called by the destructor, if not.
-        :return:
-        """
+    def close(self) -> None:
+        """Close the HDF5 file."""
         self.data.close()

--- a/miplib/data/io/fourier_correlation_data_reader.py
+++ b/miplib/data/io/fourier_correlation_data_reader.py
@@ -10,9 +10,7 @@ from miplib.data.containers.image import Image
 
 
 class FourierCorrelationDataReader:
-    """
-    A class for writing Fourier Correlation Data into a file.
-    """
+    """A class for reading Fourier Correlation Data from an HDF5 file."""
 
     # region Constructor and Destructor
     def __init__(self, file_path):
@@ -43,15 +41,20 @@ class FourierCorrelationDataReader:
             raise ValueError("No images to read")
 
         if index is not None:
-            image_name = "image_%i" % index
-            data_set = self.data["images"][image_name]
-            spacing = data_set.attrs["pixel_size"].split()[0 : len(data_set.shape)]
-            return Image(data_set[:], spacing)
+            image_name = f"image_{index}"
+            ds = self.data["images"][image_name]
+            spacing = [
+                float(s) for s in ds.attrs["pixel_size"].split()[0 : len(ds.shape)]
+            ]
+            return Image(ds[:], spacing)
 
         images = []
-        for data_set in self.data["images"]:
-            spacing = data_set.attrs["pixel_size"].split()[0 : len(data_set.shape)]
-            images.append(Image(data_set[:], spacing))
+        for name in self.data["images"]:
+            ds = self.data["images"][name]
+            spacing = [
+                float(s) for s in ds.attrs["pixel_size"].split()[0 : len(ds.shape)]
+            ]
+            images.append(Image(ds[:], spacing))
 
         return images
 
@@ -71,6 +74,7 @@ class FourierCorrelationDataReader:
                 correlation_group = self.data[group_name]["correlation"]
 
                 data_set.resolution["threshold"] = resolution_group["threshold"][:]
+                data_set.resolution["resolution"] = resolution_group.attrs["resolution"]
                 data_set.resolution["resolution-point"] = resolution_group.attrs[
                     "resolution-point"
                 ].split()[:-1]

--- a/miplib/data/io/fourier_correlation_data_writer.py
+++ b/miplib/data/io/fourier_correlation_data_writer.py
@@ -2,7 +2,6 @@ import os
 
 import h5py
 
-import miplib.ui.utils as uiutils
 from miplib.data.containers.fourier_correlation_data import (
     FourierCorrelationDataCollection,
 )
@@ -10,19 +9,15 @@ from miplib.data.containers.image import Image
 
 
 class FourierCorrelationDataWriter:
-    """
-    A class for wrtiting Fourier Correlation Data into a file.
-    """
+    """A class for writing Fourier Correlation Data into an HDF5 file."""
 
-    # region Constructor and Destructor
     def __init__(self, output_dir, filename, append=False):
-        # Create output dir, if it doesn't exist output dir if
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
 
         output_path = os.path.join(output_dir, filename)
-
-        assert output_path.endswith(".hdf5")
+        if not output_path.endswith(".hdf5"):
+            raise ValueError(f"Output path must end with .hdf5, got {output_path}")
 
         if os.path.isfile(output_path):
             self.data = h5py.File(output_path, mode="r+" if append else "w")
@@ -32,102 +27,84 @@ class FourierCorrelationDataWriter:
     def __del__(self):
         self.close()
 
-    # endregion
-
     def write_metadata(self, metadata):
-        """
-        Write a metadata dictionary to the HDF5 files header as a general description of
-        the dataset.
-        :param metadata: a dictionary with all the necessary data to be written in the file
-        """
-        assert isinstance(metadata, dict)
-
-        for key, value in metadata:
+        """Write a metadata dictionary to the HDF5 file header attributes."""
+        if not isinstance(metadata, dict):
+            raise TypeError(f"Expected dict, got {type(metadata).__name__}")
+        for key, value in metadata.items():
             self.data.attrs[key] = value
 
     def write_images(self, images):
-        """
-        Write images to the data structure
-        :param images: a tuple of Image objects, or a single image
-        """
+        """Write Image objects to the data structure."""
         if not isinstance(images, tuple):
-            images = tuple(images)
+            images = (images,)
         for image in images:
-            assert isinstance(image, Image)
+            if not isinstance(image, Image):
+                raise TypeError(f"Expected Image, got {type(image).__name__}")
 
-        self.data.create_group("images")
+        group = self.data.require_group("images")
 
-        image_name_prefix = "image_"
         for idx, image in enumerate(images):
-            image_name = image_name_prefix + str(idx)
-            self.data["images"].create_dataset(image_name, data=image)
+            image_name = f"image_{idx}"
+            group.create_dataset(image_name, data=image)
+            spacing_parts = " ".join(f"{s:g}" for s in image.spacing)
             if image.ndim == 2:
-                self.data["images"][image_name].attrs["pixel_size"] = (
-                    "%d %d (yx)" % image.spacing
-                )
+                group[image_name].attrs["pixel_size"] = f"{spacing_parts} (yx)"
             else:
-                self.data["images"][image_name].attrs["pixel_size"] = (
-                    "%d %d %d (zyx)" % image.spacing
-                )
+                group[image_name].attrs["pixel_size"] = f"{spacing_parts} (zyx)"
 
     def write_data_set(self, data):
-        """
-        Write Fourier Correlation Data (FRC, FSC etc) to the data structure.
-        :param data:
-        :type data: FourierCorrelationDataCollection
-        """
-        assert isinstance(data, FourierCorrelationDataCollection)
+        """Write Fourier Correlation Data to the data structure."""
+        if not isinstance(data, FourierCorrelationDataCollection):
+            raise TypeError(
+                f"Expected FourierCorrelationDataCollection, got {type(data).__name__}"
+            )
 
         group_prefix = "data_set_"
 
         for angle, data_set in data:
             group_name = group_prefix + angle
             if group_name in self.data:
-                if not uiutils.get_user_input(
-                    f"The dataset {angle} already exists in the file structure. Do you want"
-                    "to overwrite it?"
-                ):
-                    continue
-
-                # Create a group fot every dataset and sub-groups for the two dictionaries
-                # in the FourierCorrelationData structure.
-                data_set_group = self.data.create_group(group_name)
-                resolution_group = data_set_group.create_group("resolution")
-                correlation_group = data_set_group.create_group("correlation")
-
-                resolution_group.create_dataset(
-                    "threshold", data=data_set.resolution["threshold"]
-                )
-                resolution_group.attrs["resolution"] = data_set.resolution["resolution"]
-                resolution_group.attrs["resolution-point"] = (
-                    "%d %d (yx)" % data_set.resolution["resolution-point"]
-                )
-                resolution_group.attrs["criterion"] = data_set.resolution["criterion"]
-                resolution_group.create_dataset(
-                    "resolution-threshold-coefficients",
-                    data=data_set.resolution["resolution-threshold-coefficients"],
+                raise ValueError(
+                    f"Dataset {angle} already exists in the file. "
+                    f"Remove it first or use a different name."
                 )
 
-                correlation_group.create_dataset(
-                    "correlation", data=data_set.correlation["correlation"]
-                )
-                correlation_group.create_dataset(
-                    "frequency", data=data_set.correlation["frequency"]
-                )
-                correlation_group.create_dataset(
-                    "points-x-bin", data=data_set.correlation["points-x-bin"]
-                )
-                correlation_group.create_dataset(
-                    "curve-fit", data=data_set.correlation["curve-fit"]
-                )
-                correlation_group.create_dataset(
-                    "curve-fit-coefficients",
-                    data=data_set.correlation["curve-fit-coefficients"],
-                )
+            data_set_group = self.data.create_group(group_name)
+            resolution_group = data_set_group.create_group("resolution")
+            correlation_group = data_set_group.create_group("correlation")
+
+            resolution_group.create_dataset(
+                "threshold", data=data_set.resolution["threshold"]
+            )
+            resolution_group.attrs["resolution"] = data_set.resolution["resolution"]
+            point_str = " ".join(
+                f"{c:g}" for c in data_set.resolution["resolution-point"]
+            )
+            resolution_group.attrs["resolution-point"] = f"{point_str} (yx)"
+            resolution_group.attrs["criterion"] = data_set.resolution["criterion"]
+            resolution_group.create_dataset(
+                "resolution-threshold-coefficients",
+                data=data_set.resolution["resolution-threshold-coefficients"],
+            )
+
+            correlation_group.create_dataset(
+                "correlation", data=data_set.correlation["correlation"]
+            )
+            correlation_group.create_dataset(
+                "frequency", data=data_set.correlation["frequency"]
+            )
+            correlation_group.create_dataset(
+                "points-x-bin", data=data_set.correlation["points-x-bin"]
+            )
+            correlation_group.create_dataset(
+                "curve-fit", data=data_set.correlation["curve-fit"]
+            )
+            correlation_group.create_dataset(
+                "curve-fit-coefficients",
+                data=data_set.correlation["curve-fit-coefficients"],
+            )
 
     def close(self):
-        """
-        A function to explicitly close the data file (will be called by the destructor, if not.
-        :return:
-        """
+        """Close the HDF5 file."""
         self.data.close()

--- a/miplib/data/io/fourier_correlation_data_writer.py
+++ b/miplib/data/io/fourier_correlation_data_writer.py
@@ -9,9 +9,9 @@ from miplib.data.containers.image import Image
 
 
 class FourierCorrelationDataWriter:
-    """A class for writing Fourier Correlation Data into an HDF5 file."""
+    """Write Fourier Correlation Data into an HDF5 file."""
 
-    def __init__(self, output_dir, filename, append=False):
+    def __init__(self, output_dir: str, filename: str, append: bool = False) -> None:
         if not os.path.exists(output_dir):
             os.makedirs(output_dir)
 
@@ -19,28 +19,21 @@ class FourierCorrelationDataWriter:
         if not output_path.endswith(".hdf5"):
             raise ValueError(f"Output path must end with .hdf5, got {output_path}")
 
-        if os.path.isfile(output_path):
-            self.data = h5py.File(output_path, mode="r+" if append else "w")
-        else:
-            self.data = h5py.File(output_path, mode="w")
+        mode = "r+" if (append and os.path.isfile(output_path)) else "w"
+        self.data = h5py.File(output_path, mode=mode)
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.close()
 
-    def write_metadata(self, metadata):
+    def write_metadata(self, metadata: dict[str, object]) -> None:
         """Write a metadata dictionary to the HDF5 file header attributes."""
-        if not isinstance(metadata, dict):
-            raise TypeError(f"Expected dict, got {type(metadata).__name__}")
         for key, value in metadata.items():
             self.data.attrs[key] = value
 
-    def write_images(self, images):
+    def write_images(self, images: Image | tuple[Image, ...]) -> None:
         """Write Image objects to the data structure."""
-        if not isinstance(images, tuple):
+        if isinstance(images, Image):
             images = (images,)
-        for image in images:
-            if not isinstance(image, Image):
-                raise TypeError(f"Expected Image, got {type(image).__name__}")
 
         group = self.data.require_group("images")
 
@@ -53,22 +46,14 @@ class FourierCorrelationDataWriter:
             else:
                 group[image_name].attrs["pixel_size"] = f"{spacing_parts} (zyx)"
 
-    def write_data_set(self, data):
+    def write_data_set(self, data: FourierCorrelationDataCollection) -> None:
         """Write Fourier Correlation Data to the data structure."""
-        if not isinstance(data, FourierCorrelationDataCollection):
-            raise TypeError(
-                f"Expected FourierCorrelationDataCollection, got {type(data).__name__}"
-            )
-
         group_prefix = "data_set_"
 
         for angle, data_set in data:
             group_name = group_prefix + angle
             if group_name in self.data:
-                raise ValueError(
-                    f"Dataset {angle} already exists in the file. "
-                    f"Remove it first or use a different name."
-                )
+                continue  # skip already-written datasets
 
             data_set_group = self.data.create_group(group_name)
             resolution_group = data_set_group.create_group("resolution")
@@ -105,6 +90,6 @@ class FourierCorrelationDataWriter:
                 data=data_set.correlation["curve-fit-coefficients"],
             )
 
-    def close(self):
+    def close(self) -> None:
         """Close the HDF5 file."""
         self.data.close()

--- a/miplib/data/io/read.py
+++ b/miplib/data/io/read.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import pims
@@ -7,135 +8,89 @@ import tifffile
 import miplib.processing.itk as itkutils
 from miplib.data.containers.image import Image
 
+logger = logging.getLogger(__name__)
 scale_c = 1.0e6
 
 
-def get_image(filename, series=0, channel=0, return_type="image", bioformats=True):
-    """
-    A wrapper for the image read functions.
-    Parameters
-    :param series: The index of an image in a time series
-    :param channel: The color channel in  a multi-channel image.
-    :param bioformats: Toggle to disable bioformats reader.
-    :param filename The full path to an image
-    :param return_type Return the image as miplib Image. sitk.Image.
-           the return type can be chosen with a string ('image, 'itk').
-
-    """
-    assert return_type in ("itk", "image")
+def get_image(
+    filename: str,
+    series: int = 0,
+    channel: int = 0,
+    return_type: str = "image",
+    bioformats: bool = True,
+) -> Image | sitk.Image | tuple:
+    """Read an image from disk, dispatching on file extension."""
+    if return_type not in ("itk", "image"):
+        raise ValueError(
+            f"Unsupported return_type {return_type!r}; use 'itk' or 'image'"
+        )
 
     if filename.endswith(".mha"):
-        data = __itk_image(filename, return_type == "itk")
-    else:
-        if not filename.endswith((".tif", ".tiff")):
-            raise ValueError(
-                f"Unsupported image format: {filename}. Expected .tif, .tiff, or .mha."
-            )
-        if bioformats:
-            data = __bioformats(filename, series, channel, return_type == "itk")
-        else:
-            data = __tiff(filename, return_type == "itk")
+        return __itk_image(filename, return_type == "itk")
 
-    return data
+    if bioformats:
+        return __bioformats(filename, series, channel, return_type == "itk")
+    return __tiff(filename, return_type == "itk")
 
 
-def __itk_image(filename, return_itk=True):
-    """
-    A function for reading image file types typical to ITK (mha & mhd). This is mostly
-    of a historical significance, because in the original miplib 1 such files were
-    used, mostly for convenience.
-
-    :param filename:     Path to an ITK image
-    :param return_itk    Toggle whether to convert the ITK image into Numpy format
-    :return:             Image data as a Numpy array, voxel spacing tuple
-    """
-    assert filename.endswith((".mha", ".mhd"))
+def __itk_image(filename: str, return_itk: bool = True) -> sitk.Image | Image:
+    """Read an ITK-supported image (.mha/.mhd)."""
+    if not filename.endswith((".mha", ".mhd")):
+        raise ValueError(f"Expected .mha or .mhd extension, got {filename}")
     image = sitk.ReadImage(filename)
     if return_itk:
         return image
-    else:
-        return itkutils.convert_from_itk_image(image)
+    return itkutils.convert_from_itk_image(image)
 
 
-def __tiff(filename, memmap=False, return_itk=False):
-    """
-    ImageJ has a bit peculiar way of saving image metadata, especially the tags
-    for voxel spacing, which is of main interest in miplib. This function reads
-    a 3D TIFF into a Numpy array and also calculates the voxel spacing parameters
-    from the TIFF tags. I will not guarantee that this will work with any other TIFF
-    files.
+def __tiff(
+    filename: str,
+    return_itk: bool = False,
+) -> tuple | sitk.Image:
+    """Read an ImageJ-style 3D TIFF, extracting voxel spacing from tags."""
+    if not filename.endswith((".tif", ".tiff")):
+        raise ValueError(f"Expected .tif or .tiff extension, got {filename}")
 
-    :param filename:    Path to a TIFF.
-    :param memmap:      Enables Memory mapping in case the TIFF file is too large to
-                        be read in memory completely.
-    :param return_itk  Converts the Image data into a sitk.Image. This can be used
-                        when single images are needed, instead of using the HDF5
-                        structure adopted in miplib.
-    :return:            Image data either as a Numpy array, voxel spacing tuple or a
-                        sitk.Image
-    """
-    assert filename.endswith((".tif", ".tiff"))
-    tags = {}
-    # Read images and tags
-    with tifffile.TiffFile(filename) as image:
-        # Get images
-        images = image.asarray(memmap=memmap)
-        # Get tags
-        page = image[0]
-        for tag in list(page.tags.values()):
-            tags[tag.name] = tag.value
+    tags: dict[str, object] = {}
+    with tifffile.TiffFile(filename) as tiff:
+        images = tiff.asarray()
+        page = tiff.pages[0]
+        if hasattr(page, "tags"):
+            for tag in list(page.tags.values()):  # type: ignore[union-attr]
+                tags[tag.name] = tag.value
 
-    # Figure out z-spacing, which in ImageJ is hidden in the "image_description"
-    # header (why, one might ask).
-    if "image_description" not in tags:
-        raise ValueError(
-            "This TIFF does not have an ImageJ-style image_description tag. "
-            "Use --bioformats or convert to .mha format."
-        )
-    image_descriptor = tags["image_description"].split("\n")
-    z_spacing = None
-    for line in image_descriptor:
-        if "spacing" in line:
-            z_spacing = float(line.split("=")[-1])
-            break
-    if z_spacing is None:
-        raise ValueError(
-            "Could not determine z-spacing from the TIFF image description."
-        )
+    z_spacing = _extract_z_spacing(tags)
 
-    # Note: the TIFF tags use XResolution/YResolution naming, but here they
-    # are mapped to Z, Y, X (numpy axis order). The writer in write.py
-    # performs the inverse mapping, so round-trips are consistent.
+    # XResolution/YResolution map to numpy Y/X axes (Z, Y, X order).
+    # The writer in write.py performs the inverse mapping.
     spacing = (
         z_spacing,
-        scale_c / tags["x_resolution"][0],
-        scale_c / tags["y_resolution"][0],
+        scale_c / float(tags["x_resolution"][0]),  # type: ignore[index]
+        scale_c / float(tags["y_resolution"][0]),  # type: ignore[index]
     )
 
-    # print spacing
     if return_itk:
         return itkutils.convert_from_numpy(images, spacing)
-    else:
-        return images, spacing
+    return images, spacing
 
 
-def __itk_transform(path, return_itk=False):
-    """
-    Prior to starting to use the HDF5 format data storage images and spatial
-    transforms were saved as separate image files on the hard drive. This
-    function can be used to read a spatial transform saved from ITK. It is
-    to transfer old files into the HDF5 format storage.
+def _extract_z_spacing(tags: dict[str, object]) -> float:
+    """Extract z-spacing from ImageJ-style image_description tag."""
+    if "image_description" not in tags:
+        logger.warning("No ImageJ image_description tag; using z-spacing = 1.0")
+        return 1.0
 
-    Parameters
-    ----------
-    path        Path to the transform file (usually txt ended)
+    image_descriptor = str(tags["image_description"]).split("\n")
+    for line in image_descriptor:
+        if "spacing" in line:
+            return float(line.split("=")[-1])
 
-    Returns     Returns the transform type integer, parameters and fixed
-                parameters.
-    -------
+    logger.warning("No spacing entry in image_description; using z-spacing = 1.0")
+    return 1.0
 
-    """
 
+def __itk_transform(path: str, return_itk: bool = False) -> tuple | sitk.Transform:
+    """Read an ITK spatial transform from disk."""
     if not os.path.isfile(path):
         raise ValueError(f"Not a valid path: {path}")
 
@@ -144,62 +99,49 @@ def __itk_transform(path, return_itk=False):
     if return_itk:
         return transform
 
-    else:
-        # #TODO: Check that this makes any sense. Also consult the ITK HDF implementation for ideas
-        # with open(path, 'r') as f:
-        #     for line in f:
-        #         if line.startswith('Transform:'):
-        #             type_string = line.split(': ')[1].split('_')[0]
-        #             if "VersorRigid" in type_string:
-        #                 transform_type = itk_transforms_c['sitkVersorRigid']
-        #                 break
-        #             else:
-        #                 raise NotImplementedError("Unknown transform type: "
-        #                                           "%s" % type_string)
-        transform_type = transform.GetName()
-        params = transform.GetParameters()
-        fixed_params = transform.GetFixedParameters()
-        return transform_type, params, fixed_params
+    transform_type = transform.GetName()
+    params = transform.GetParameters()
+    fixed_params = transform.GetFixedParameters()
+    return transform_type, params, fixed_params
 
 
-def __bioformats(filename, series=0, channel=0, return_itk=False):
-    """
-    Read an image using the Bioformats importer. Good for most microscopy formats.
-
-    :param filename:
-    :param series:
-    :param return_itk:
-    :return:
-    """
+def __bioformats(
+    filename: str,
+    series: int = 0,
+    channel: int = 0,
+    return_itk: bool = False,
+) -> Image | sitk.Image:
+    """Read an image through the Bioformats importer (most microscopy formats)."""
     if not pims.bioformats.available():
-        raise ImportError("Please install jpype in order to use the bioformats reader.")
-    image = pims.bioformats.BioformatsReader(filename, series=series)
+        raise ImportError(
+            "jpype is required for the bioformats reader. "
+            "Install with: uv sync --group dev"
+        )
+    reader = pims.bioformats.BioformatsReader(filename, series=series)
 
-    # Get Pixel/Voxel size information
-    if "z" not in image.axes:
-        spacing = (
-            image.metadata.PixelsPhysicalSizeY(0),
-            image.metadata.PixelsPhysicalSizeX(0),
+    if "z" not in reader.axes:
+        spacing: tuple[float, ...] = (
+            reader.metadata.PixelsPhysicalSizeY(0),
+            reader.metadata.PixelsPhysicalSizeX(0),
         )
     else:
         spacing = (
-            image.metadata.PixelsPhysicalSizeZ(0),
-            image.metadata.PixelsPhysicalSizeY(0),
-            image.metadata.PixelsPhysicalSizeX(0),
+            reader.metadata.PixelsPhysicalSizeZ(0),
+            reader.metadata.PixelsPhysicalSizeY(0),
+            reader.metadata.PixelsPhysicalSizeX(0),
         )
 
-    # Get color channel
-    if "c" in image.sizes:
-        image.iter_axes = "c"
-        if not len(image) > channel:
+    if "c" in reader.sizes:
+        reader.iter_axes = "c"
+        if not len(reader) > channel:
             raise IndexError(
-                f"Requested channel {channel} but image has only {len(image)} channels."
+                f"Requested channel {channel} but image has only "
+                f"{len(reader)} channels."
             )
-        image = image[channel]
+        reader = reader[channel]
     else:
-        image = image[0]
+        reader = reader[0]
 
     if return_itk:
-        return itkutils.convert_from_numpy(image, spacing)
-    else:
-        return Image(image, spacing)
+        return itkutils.convert_from_numpy(reader, spacing)
+    return Image(reader, spacing)

--- a/miplib/data/io/read.py
+++ b/miplib/data/io/read.py
@@ -27,6 +27,10 @@ def get_image(filename, series=0, channel=0, return_type="image", bioformats=Tru
     if filename.endswith(".mha"):
         data = __itk_image(filename, return_type == "itk")
     else:
+        if not filename.endswith((".tif", ".tiff")):
+            raise ValueError(
+                f"Unsupported image format: {filename}. Expected .tif, .tiff, or .mha."
+            )
         if bioformats:
             data = __bioformats(filename, series, channel, return_type == "itk")
         else:
@@ -83,16 +87,25 @@ def __tiff(filename, memmap=False, return_itk=False):
 
     # Figure out z-spacing, which in ImageJ is hidden in the "image_description"
     # header (why, one might ask).
+    if "image_description" not in tags:
+        raise ValueError(
+            "This TIFF does not have an ImageJ-style image_description tag. "
+            "Use --bioformats or convert to .mha format."
+        )
     image_descriptor = tags["image_description"].split("\n")
     z_spacing = None
     for line in image_descriptor:
         if "spacing" in line:
             z_spacing = float(line.split("=")[-1])
             break
-    assert z_spacing is not None
+    if z_spacing is None:
+        raise ValueError(
+            "Could not determine z-spacing from the TIFF image description."
+        )
 
-    # Create a tuple for zxy-spacing. The order of the dimensions follows that of the
-    # image data
+    # Note: the TIFF tags use XResolution/YResolution naming, but here they
+    # are mapped to Z, Y, X (numpy axis order). The writer in write.py
+    # performs the inverse mapping, so round-trips are consistent.
     spacing = (
         z_spacing,
         scale_c / tags["x_resolution"][0],
@@ -158,9 +171,8 @@ def __bioformats(filename, series=0, channel=0, return_itk=False):
     :param return_itk:
     :return:
     """
-    assert pims.bioformats.available(), (
-        "Please install jpype in order to use the bioformats reader."
-    )
+    if not pims.bioformats.available():
+        raise ImportError("Please install jpype in order to use the bioformats reader.")
     image = pims.bioformats.BioformatsReader(filename, series=series)
 
     # Get Pixel/Voxel size information
@@ -179,7 +191,10 @@ def __bioformats(filename, series=0, channel=0, return_itk=False):
     # Get color channel
     if "c" in image.sizes:
         image.iter_axes = "c"
-        assert len(image) > channel
+        if not len(image) > channel:
+            raise IndexError(
+                f"Requested channel {channel} but image has only {len(image)} channels."
+            )
         image = image[channel]
     else:
         image = image[0]

--- a/miplib/data/io/read.py
+++ b/miplib/data/io/read.py
@@ -137,20 +137,11 @@ def __bioformats(
             reader.metadata.PixelsPhysicalSizeX(0),
         )
     else:
-        try:
-            spacing = (
-                reader.metadata.PixelsPhysicalSizeZ(0),
-                reader.metadata.PixelsPhysicalSizeY(0),
-                reader.metadata.PixelsPhysicalSizeX(0),
-            )
-        except AttributeError:
-            # OME-TIFF files expose PixelsPhysicalSizeZ but not Y/X.
-            # Fall back to 2D spacing with Y/X defaults.
-            spacing = (
-                reader.metadata.PixelsPhysicalSizeZ(0),
-                1.0,
-                1.0,
-            )
+        spacing = (
+            reader.metadata.PixelsPhysicalSizeZ(0),
+            reader.metadata.PixelsPhysicalSizeY(0),
+            reader.metadata.PixelsPhysicalSizeX(0),
+        )
 
     if "c" in reader.sizes:
         reader.iter_axes = "c"

--- a/miplib/data/io/read.py
+++ b/miplib/data/io/read.py
@@ -63,11 +63,18 @@ def __tiff(
 
     # XResolution/YResolution map to numpy Y/X axes (Z, Y, X order).
     # The writer in write.py performs the inverse mapping.
-    spacing = (
-        z_spacing,
-        scale_c / float(tags["x_resolution"][0]),  # type: ignore[index]
-        scale_c / float(tags["y_resolution"][0]),  # type: ignore[index]
-    )
+    x_res = tags.get("x_resolution")
+    y_res = tags.get("y_resolution")
+    if x_res is None or y_res is None:
+        logger.warning("No XResolution/YResolution tags; using default spacing (1, 1).")
+        xy_spacing = (1.0, 1.0)
+    else:
+        xy_spacing = (
+            scale_c / float(x_res[0]),  # type: ignore[index]
+            scale_c / float(y_res[0]),  # type: ignore[index]
+        )
+
+    spacing = (z_spacing,) + xy_spacing
 
     if return_itk:
         return itkutils.convert_from_numpy(images, spacing)

--- a/miplib/data/io/read.py
+++ b/miplib/data/io/read.py
@@ -126,6 +126,11 @@ def __bioformats(
         )
     reader = pims.bioformats.BioformatsReader(filename, series=series)
 
+    # Bioformats may interpret z-slices as channels if the file lacks OME-XML
+    # metadata (common with plain tifffile-written z-stacks). Bundle 'c' as 'z'.
+    if "c" in reader.sizes and "z" not in reader.axes:
+        reader.bundle_axes = "cyx"
+
     if "z" not in reader.axes:
         spacing: tuple[float, ...] = (
             reader.metadata.PixelsPhysicalSizeY(0),

--- a/miplib/data/io/read.py
+++ b/miplib/data/io/read.py
@@ -137,11 +137,20 @@ def __bioformats(
             reader.metadata.PixelsPhysicalSizeX(0),
         )
     else:
-        spacing = (
-            reader.metadata.PixelsPhysicalSizeZ(0),
-            reader.metadata.PixelsPhysicalSizeY(0),
-            reader.metadata.PixelsPhysicalSizeX(0),
-        )
+        try:
+            spacing = (
+                reader.metadata.PixelsPhysicalSizeZ(0),
+                reader.metadata.PixelsPhysicalSizeY(0),
+                reader.metadata.PixelsPhysicalSizeX(0),
+            )
+        except AttributeError:
+            # OME-TIFF files expose PixelsPhysicalSizeZ but not Y/X.
+            # Fall back to 2D spacing with Y/X defaults.
+            spacing = (
+                reader.metadata.PixelsPhysicalSizeZ(0),
+                1.0,
+                1.0,
+            )
 
     if "c" in reader.sizes:
         reader.iter_axes = "c"

--- a/miplib/data/io/read.py
+++ b/miplib/data/io/read.py
@@ -15,7 +15,6 @@ def get_image(
     series: int = 0,
     channel: int = 0,
     return_type: str = "image",
-    bioformats: bool = True,  # noqa: ARG001 kept for API compat
 ) -> Image | sitk.Image:
     """Read an image from disk via bioformats (or ITK for .mha files)."""
     if return_type not in ("itk", "image"):

--- a/miplib/data/io/read.py
+++ b/miplib/data/io/read.py
@@ -3,13 +3,11 @@ import os
 
 import pims
 import SimpleITK as sitk
-import tifffile
 
 import miplib.processing.itk as itkutils
 from miplib.data.containers.image import Image
 
 logger = logging.getLogger(__name__)
-scale_c = 1.0e6
 
 
 def get_image(
@@ -17,9 +15,9 @@ def get_image(
     series: int = 0,
     channel: int = 0,
     return_type: str = "image",
-    bioformats: bool = True,
-) -> Image | sitk.Image | tuple:
-    """Read an image from disk, dispatching on file extension."""
+    bioformats: bool = True,  # noqa: ARG001 kept for API compat
+) -> Image | sitk.Image:
+    """Read an image from disk via bioformats (or ITK for .mha files)."""
     if return_type not in ("itk", "image"):
         raise ValueError(
             f"Unsupported return_type {return_type!r}; use 'itk' or 'image'"
@@ -28,9 +26,7 @@ def get_image(
     if filename.endswith(".mha"):
         return __itk_image(filename, return_type == "itk")
 
-    if bioformats:
-        return __bioformats(filename, series, channel, return_type == "itk")
-    return __tiff(filename, return_type == "itk")
+    return __bioformats(filename, series, channel, return_type == "itk")
 
 
 def __itk_image(filename: str, return_itk: bool = True) -> sitk.Image | Image:
@@ -41,59 +37,6 @@ def __itk_image(filename: str, return_itk: bool = True) -> sitk.Image | Image:
     if return_itk:
         return image
     return itkutils.convert_from_itk_image(image)
-
-
-def __tiff(
-    filename: str,
-    return_itk: bool = False,
-) -> tuple | sitk.Image:
-    """Read an ImageJ-style 3D TIFF, extracting voxel spacing from tags."""
-    if not filename.endswith((".tif", ".tiff")):
-        raise ValueError(f"Expected .tif or .tiff extension, got {filename}")
-
-    tags: dict[str, object] = {}
-    with tifffile.TiffFile(filename) as tiff:
-        images = tiff.asarray()
-        page = tiff.pages[0]
-        if hasattr(page, "tags"):
-            for tag in list(page.tags.values()):  # type: ignore[union-attr]
-                tags[tag.name] = tag.value
-
-    z_spacing = _extract_z_spacing(tags)
-
-    # XResolution/YResolution map to numpy Y/X axes (Z, Y, X order).
-    # The writer in write.py performs the inverse mapping.
-    x_res = tags.get("x_resolution")
-    y_res = tags.get("y_resolution")
-    if x_res is None or y_res is None:
-        logger.warning("No XResolution/YResolution tags; using default spacing (1, 1).")
-        xy_spacing = (1.0, 1.0)
-    else:
-        xy_spacing = (
-            scale_c / float(x_res[0]),  # type: ignore[index]
-            scale_c / float(y_res[0]),  # type: ignore[index]
-        )
-
-    spacing = (z_spacing,) + xy_spacing
-
-    if return_itk:
-        return itkutils.convert_from_numpy(images, spacing)
-    return images, spacing
-
-
-def _extract_z_spacing(tags: dict[str, object]) -> float:
-    """Extract z-spacing from ImageJ-style image_description tag."""
-    if "image_description" not in tags:
-        logger.warning("No ImageJ image_description tag; using z-spacing = 1.0")
-        return 1.0
-
-    image_descriptor = str(tags["image_description"]).split("\n")
-    for line in image_descriptor:
-        if "spacing" in line:
-            return float(line.split("=")[-1])
-
-    logger.warning("No spacing entry in image_description; using z-spacing = 1.0")
-    return 1.0
 
 
 def __itk_transform(path: str, return_itk: bool = False) -> tuple | sitk.Transform:

--- a/miplib/data/io/write.py
+++ b/miplib/data/io/write.py
@@ -23,27 +23,29 @@ def __itk_image(path: str, image: Image) -> None:
 
 
 def __tiff(path: str, image: Image, spacing: list[float]) -> None:
-    """Write a TIFF (auto-converted to BigTIFF if needed)."""
-    if image.ndim >= 3:
-        with tifffile.TiffWriter(path, ome=True) as tw:
-            metadata: dict[str, object] = {
-                "axes": "ZYX",
-                "PhysicalSizeZ": spacing[0],
-                "PhysicalSizeZUnit": "\u00b5m",
-            }
-            metadata["PhysicalSizeY"] = spacing[1]
-            metadata["PhysicalSizeYUnit"] = "\u00b5m"
-            metadata["PhysicalSizeX"] = spacing[2]
-            metadata["PhysicalSizeXUnit"] = "\u00b5m"
-            tw.write(
-                image,
-                resolution=(1.0 / spacing[1], 1.0 / spacing[2]),
-                metadata=metadata,
-            )
+    """Write a TIFF with OME metadata (auto-converted to BigTIFF if needed)."""
+    if image.ndim == 2:
+        axes = "YX"
+        resolution: tuple[float, float] = (1.0 / spacing[0], 1.0 / spacing[1])
+        metadata: dict[str, object] = {
+            "axes": axes,
+            "PhysicalSizeY": spacing[0],
+            "PhysicalSizeYUnit": "\u00b5m",
+            "PhysicalSizeX": spacing[1],
+            "PhysicalSizeXUnit": "\u00b5m",
+        }
     else:
-        tifffile.imwrite(
-            path,
-            image,
-            imagej=True,
-            resolution=(1.0 / spacing[0], 1.0 / spacing[1]),
-        )
+        axes = "ZYX"
+        resolution = (1.0 / spacing[1], 1.0 / spacing[2])
+        metadata = {
+            "axes": axes,
+            "PhysicalSizeZ": spacing[0],
+            "PhysicalSizeZUnit": "\u00b5m",
+            "PhysicalSizeY": spacing[1],
+            "PhysicalSizeYUnit": "\u00b5m",
+            "PhysicalSizeX": spacing[2],
+            "PhysicalSizeXUnit": "\u00b5m",
+        }
+
+    with tifffile.TiffWriter(path, ome=True) as tw:
+        tw.write(image, resolution=resolution, metadata=metadata)

--- a/miplib/data/io/write.py
+++ b/miplib/data/io/write.py
@@ -5,15 +5,8 @@ import miplib.processing.itk as itkutils
 from miplib.data.containers.image import Image
 
 
-def image(path, image):
-    """Write an Image to disk, dispatching on file extension.
-
-    :param path:    A full path to the image.
-    :param image:   An Image (ndarray subclass with spacing).
-    """
-    if not isinstance(image, Image):
-        raise TypeError(f"Expected Image, got {type(image).__name__}")
-
+def image(path: str, image: Image) -> None:
+    """Write an Image to disk, dispatching on file extension."""
     if path.endswith((".tiff", ".tif")):
         __tiff(path, image, image.spacing)
     elif path.endswith((".mha", ".mhd")):
@@ -24,44 +17,28 @@ def image(path, image):
         )
 
 
-def __itk_image(path, image):
+def __itk_image(path: str, image: Image) -> None:
     """Write an Image in ITK format (.mha/.mhd)."""
-    if not isinstance(image, Image):
-        raise TypeError(f"Expected Image, got {type(image).__name__}")
-    image = itkutils.convert_to_itk_image(image)
-    sitk.WriteImage(image, path)
+    sitk.WriteImage(itkutils.convert_to_itk_image(image), path)
 
 
-def __imagej_tiff(path, image, spacing):
-    """
-    Write a TIFF in ImageJ mode. May improve compatibility with
-    older imageJ. I would recommend using the other one instead.
-    :param path:    A full path to the image.
-    :param image:   An image as :type image: numpy.ndarray.
-    :param spacing: Pixel size ZXY, as a :type spacing: list.
-    """
-    tifffile.imsave(path, image, imagej=True, resolution=[1.0 / x for x in spacing])
-
-
-def __tiff(path, image, spacing):
-    """
-    Write a TIFF. Will be automatically converted into BigTIFF, if the
-    file is too big for regulare TIFF definition.
-
-    :param path:    A full path to the image.
-    :param image:   An image as Numpy.ndarray.
-    :param spacing: Pixel size ZXY, as a list.
-    """
-
+def __tiff(path: str, image: Image, spacing: list[float]) -> None:
+    """Write a TIFF (auto-converted to BigTIFF if needed)."""
     if image.ndim >= 3:
-        image_description = f"images={image.shape[0]} slices={image.shape[0]} unit=micron spacing={spacing[0]}"
-        tifffile.imsave(
+        image_description = (
+            f"images={image.shape[0]} slices={image.shape[0]} "
+            f"unit=micron spacing={spacing[0]}"
+        )
+        tifffile.imwrite(
             path,
             image,
             resolution=(1.0 / spacing[1], 1.0 / spacing[2]),
             metadata={"description": image_description},
         )
     else:
-        tifffile.imsave(
-            path, image, imagej=True, resolution=(1.0 / spacing[0], 1.0 / spacing[1])
+        tifffile.imwrite(
+            path,
+            image,
+            imagej=True,
+            resolution=(1.0 / spacing[0], 1.0 / spacing[1]),
         )

--- a/miplib/data/io/write.py
+++ b/miplib/data/io/write.py
@@ -6,34 +6,28 @@ from miplib.data.containers.image import Image
 
 
 def image(path, image):
-    """
-    A wrapper for the various image writing functions. The consumers
-    should only call this function
+    """Write an Image to disk, dispatching on file extension.
 
     :param path:    A full path to the image.
-    :param image:   An image as :type image: numpy.ndarray or sitk.image.
-
-    :return:
+    :param image:   An Image (ndarray subclass with spacing).
     """
-
-    assert isinstance(image, Image)
+    if not isinstance(image, Image):
+        raise TypeError(f"Expected Image, got {type(image).__name__}")
 
     if path.endswith((".tiff", ".tif")):
         __tiff(path, image, image.spacing)
-    else:
+    elif path.endswith((".mha", ".mhd")):
         __itk_image(path, image)
+    else:
+        raise ValueError(
+            f"Unsupported file extension: {path}. Expected .tif, .tiff, .mha, or .mhd."
+        )
 
 
 def __itk_image(path, image):
-    """
-    A writer for ITK supported image formats.
-
-    :param path:    A full path to the image.
-    :param image:   An image as :type image: numpy.ndarray.
-    :param spacing: Pixel size ZXY, as a :type spacing: list.
-    """
-    assert isinstance(image, Image)
-
+    """Write an Image in ITK format (.mha/.mhd)."""
+    if not isinstance(image, Image):
+        raise TypeError(f"Expected Image, got {type(image).__name__}")
     image = itkutils.convert_to_itk_image(image)
     sitk.WriteImage(image, path)
 

--- a/miplib/data/io/write.py
+++ b/miplib/data/io/write.py
@@ -25,16 +25,16 @@ def __itk_image(path: str, image: Image) -> None:
 def __tiff(path: str, image: Image, spacing: list[float]) -> None:
     """Write a TIFF (auto-converted to BigTIFF if needed)."""
     if image.ndim >= 3:
-        image_description = (
-            f"images={image.shape[0]} slices={image.shape[0]} "
-            f"unit=micron spacing={spacing[0]}"
-        )
-        tifffile.imwrite(
-            path,
-            image,
-            resolution=(1.0 / spacing[1], 1.0 / spacing[2]),
-            metadata={"description": image_description},
-        )
+        with tifffile.TiffWriter(path, ome=True) as tw:
+            metadata: dict[str, object] = {"axes": "ZYX"}
+            if len(spacing) >= 3:
+                metadata["PhysicalSizeZ"] = spacing[0]
+                metadata["PhysicalSizeZUnit"] = "µm"
+            tw.write(
+                image,
+                resolution=(1.0 / spacing[1], 1.0 / spacing[2]),
+                metadata=metadata,
+            )
     else:
         tifffile.imwrite(
             path,

--- a/miplib/data/io/write.py
+++ b/miplib/data/io/write.py
@@ -26,10 +26,15 @@ def __tiff(path: str, image: Image, spacing: list[float]) -> None:
     """Write a TIFF (auto-converted to BigTIFF if needed)."""
     if image.ndim >= 3:
         with tifffile.TiffWriter(path, ome=True) as tw:
-            metadata: dict[str, object] = {"axes": "ZYX"}
-            if len(spacing) >= 3:
-                metadata["PhysicalSizeZ"] = spacing[0]
-                metadata["PhysicalSizeZUnit"] = "µm"
+            metadata: dict[str, object] = {
+                "axes": "ZYX",
+                "PhysicalSizeZ": spacing[0],
+                "PhysicalSizeZUnit": "\u00b5m",
+            }
+            metadata["PhysicalSizeY"] = spacing[1]
+            metadata["PhysicalSizeYUnit"] = "\u00b5m"
+            metadata["PhysicalSizeX"] = spacing[2]
+            metadata["PhysicalSizeXUnit"] = "\u00b5m"
             tw.write(
                 image,
                 resolution=(1.0 / spacing[1], 1.0 / spacing[2]),

--- a/miplib/data/iterators/__init__.py
+++ b/miplib/data/iterators/__init__.py
@@ -1,0 +1,23 @@
+"""Fourier space iterators for FRC/FSC resolution analysis."""
+
+from miplib.data.iterators.fourier_ring_iterators import (
+    FourierRingIterator,
+    SectionedFourierRingIterator,
+)
+from miplib.data.iterators.fourier_shell_iterators import (
+    AxialExcludeSectionedFourierShellIterator,
+    FourierShellIterator,
+    HollowSectionedFourierShellIterator,
+    RotatingFourierShellIterator,
+    SectionedFourierShellIterator,
+)
+
+__all__ = [
+    "FourierRingIterator",
+    "SectionedFourierRingIterator",
+    "FourierShellIterator",
+    "SectionedFourierShellIterator",
+    "HollowSectionedFourierShellIterator",
+    "AxialExcludeSectionedFourierShellIterator",
+    "RotatingFourierShellIterator",
+]

--- a/miplib/data/iterators/fourier_ring_iterators.py
+++ b/miplib/data/iterators/fourier_ring_iterators.py
@@ -11,7 +11,7 @@ class FourierRingIterator:
     and iterates over concentric rings of thickness *d_bin*.
     """
 
-    def __init__(self, shape, d_bin):
+    def __init__(self, shape: tuple[int, int], d_bin: int | float) -> None:
         if len(shape) != 2:
             raise ValueError(f"shape must be 2D, got shape {shape}")
 
@@ -28,22 +28,22 @@ class FourierRingIterator:
         self._radii = np.arange(0, self.freq_nyq, self.d_bin)
 
     @property
-    def radii(self):
+    def radii(self) -> np.ndarray:
         return self._radii
 
     @property
-    def nbins(self):
+    def nbins(self) -> int:
         return self._nbins
 
-    def get_points_on_ring(self, ring_start, ring_stop):
+    def get_points_on_ring(self, ring_start: float, ring_stop: float) -> np.ndarray:
         arr_inf = self.r >= ring_start
         arr_sup = self.r < ring_stop
         return arr_inf * arr_sup
 
-    def __iter__(self):
+    def __iter__(self) -> "FourierRingIterator":
         return self
 
-    def __next__(self):
+    def __next__(self) -> tuple[tuple[np.ndarray, ...], int]:
         if self.current_ring < self._nbins:
             ring = self.get_points_on_ring(
                 self.current_ring * self.d_bin, (self.current_ring + 1) * self.d_bin
@@ -62,7 +62,9 @@ class SectionedFourierRingIterator(FourierRingIterator):
     centered at a settable rotation angle.
     """
 
-    def __init__(self, shape, d_bin, d_angle):
+    def __init__(
+        self, shape: tuple[int, int], d_bin: int | float, d_angle: float
+    ) -> None:
         FourierRingIterator.__init__(self, shape, d_bin)
 
         self.d_angle = converters.degrees_to_radians(d_angle)
@@ -72,20 +74,20 @@ class SectionedFourierRingIterator(FourierRingIterator):
         self.phi += self.d_angle / 2
         self.phi[self.phi >= 2 * np.pi] -= 2 * np.pi
 
-        self._angle = 0
-        self.angle_sector = self.get_angle_sector(0, self.d_angle)
+        self._angle = 0.0
+        self.angle_sector = self.get_angle_sector(0.0, self.d_angle)
 
     @property
-    def angle(self):
+    def angle(self) -> float:
         return self._angle
 
     @angle.setter
-    def angle(self, value):
+    def angle(self, value: float) -> None:
         angle = converters.degrees_to_radians(value)
         self._angle = angle
         self.angle_sector = self.get_angle_sector(angle, angle + self.d_angle)
 
-    def get_angle_sector(self, phi_min, phi_max):
+    def get_angle_sector(self, phi_min: float, phi_max: float) -> np.ndarray:
         """Return a boolean mask for the angular sector [phi_min, phi_max).
 
         Includes the 180-degree counterpart for Fourier-space symmetry.
@@ -98,13 +100,15 @@ class SectionedFourierRingIterator(FourierRingIterator):
 
         return arr_inf * arr_sup + arr_inf_neg * arr_sup_neg
 
-    def __getitem__(self, limits):
+    def __getitem__(
+        self, limits: tuple[float, float, float, float]
+    ) -> tuple[np.ndarray, ...]:
         (ring_start, ring_stop, angle_min, angle_max) = limits
         ring = self.get_points_on_ring(ring_start, ring_stop)
         cone = self.get_angle_sector(angle_min, angle_max)
         return np.where(ring * cone)
 
-    def __next__(self):
+    def __next__(self) -> tuple[tuple[np.ndarray, ...], int]:
         if self.current_ring < self._nbins:
             ring = self.get_points_on_ring(
                 self.current_ring * self.d_bin, (self.current_ring + 1) * self.d_bin

--- a/miplib/data/iterators/fourier_ring_iterators.py
+++ b/miplib/data/iterators/fourier_ring_iterators.py
@@ -1,38 +1,29 @@
-from math import floor
-
 import numpy as np
 
 import miplib.processing.converters as converters
+from miplib.data.coordinates.polar import SimplePolarIndexer
 
 
 class FourierRingIterator:
-    """
-    A Fourier ring iterator class for 2D images. Calculates a 2D polar coordinate
-    centered at the geometric center of the data shape.
+    """A Fourier ring iterator for 2D images.
+
+    Computes a polar coordinate grid centered at the geometric center
+    and iterates over concentric rings of thickness *d_bin*.
     """
 
     def __init__(self, shape, d_bin):
-        """
-        :param shape: the volume shape
-        :param d_bin: thickness of the ring in pixels
-        """
+        if len(shape) != 2:
+            raise ValueError(f"shape must be 2D, got shape {shape}")
 
-        assert len(shape) == 2
-
-        # Get bin size
         self.d_bin = d_bin
-        self.ring_start = 0
-        self._nbins = int(floor(shape[0] / (2 * self.d_bin)))
-        # Create Fourier grid
-        axes = (np.arange(-np.floor(i / 2.0), np.ceil(i / 2.0)) for i in shape)
-        y, x = np.meshgrid(*axes)
+        self._nbins = int(np.floor(shape[0] / (2 * self.d_bin)))
+
+        indexer = SimplePolarIndexer(shape)
+        self.r = indexer.r
+        y, x = indexer.meshgrid
         self.meshgrid = (y, x)
 
-        # Create OP vector array
-        self.r = np.sqrt(x**2 + y**2)
-        # Current ring index
-        self.current_ring = self.ring_start
-
+        self.current_ring = 0
         self.freq_nyq = int(np.floor(shape[0] / 2.0))
         self._radii = np.arange(0, self.freq_nyq, self.d_bin)
 
@@ -47,7 +38,6 @@ class FourierRingIterator:
     def get_points_on_ring(self, ring_start, ring_stop):
         arr_inf = self.r >= ring_start
         arr_sup = self.r < ring_stop
-
         return arr_inf * arr_sup
 
     def __iter__(self):
@@ -66,33 +56,24 @@ class FourierRingIterator:
 
 
 class SectionedFourierRingIterator(FourierRingIterator):
-    """
-    An iterator for 2D images. Includes the option use only a specific rotated section of
-    the fourier ring for FRC calculation.
+    """A Fourier ring iterator with angular sectoring.
+
+    Each ring is restricted to an angular cone of width *d_angle* (degrees),
+    centered at a settable rotation angle.
     """
 
     def __init__(self, shape, d_bin, d_angle):
-        """
-        :param shape: Shape of the data
-        :param d_bin: The radius increment size (pixels)
-        :param d_angle: The angle increment size (degrees)
-        """
-
         FourierRingIterator.__init__(self, shape, d_bin)
 
         self.d_angle = converters.degrees_to_radians(d_angle)
 
         y, x = self.meshgrid
-
-        # Create inclination and azimuth angle arrays
         self.phi = np.arctan2(y, x) + np.pi
-
         self.phi += self.d_angle / 2
         self.phi[self.phi >= 2 * np.pi] -= 2 * np.pi
 
         self._angle = 0
-
-        self.angle_sector = self.get_angle_sector(0, d_bin)
+        self.angle_sector = self.get_angle_sector(0, self.d_angle)
 
     @property
     def angle(self):
@@ -105,14 +86,9 @@ class SectionedFourierRingIterator(FourierRingIterator):
         self.angle_sector = self.get_angle_sector(angle, angle + self.d_angle)
 
     def get_angle_sector(self, phi_min, phi_max):
-        """
-        Use this to extract
-        a section from a sphere that is defined by start and stop angles.
+        """Return a boolean mask for the angular sector [phi_min, phi_max).
 
-        :param phi_min: the angle at which to start the section, in radians
-        :param phi_max: the angle at which to stop the section, in radians
-        :return:
-
+        Includes the 180-degree counterpart for Fourier-space symmetry.
         """
         arr_inf = self.phi >= phi_min
         arr_sup = self.phi < phi_max
@@ -123,16 +99,9 @@ class SectionedFourierRingIterator(FourierRingIterator):
         return arr_inf * arr_sup + arr_inf_neg * arr_sup_neg
 
     def __getitem__(self, limits):
-        """
-        Get a single conical section of a 2D ring.
-
-        :param limits:  a list of parameters (ring_start, ring_stop, angle_min, angle_ma)
-        that are required to define a single section of a fourier ring.
-        """
         (ring_start, ring_stop, angle_min, angle_max) = limits
         ring = self.get_points_on_ring(ring_start, ring_stop)
         cone = self.get_angle_sector(angle_min, angle_max)
-
         return np.where(ring * cone)
 
     def __next__(self):

--- a/miplib/data/iterators/fourier_shell_iterators.py
+++ b/miplib/data/iterators/fourier_shell_iterators.py
@@ -1,36 +1,31 @@
-from math import floor
-
 import numpy as np
 
 import miplib.processing.converters as converters
-import miplib.processing.itk as itkutils
-import miplib.processing.ndarray as nputils
+from miplib.data.coordinates.polar import SimplePolarIndexer
 
 
 class FourierShellIterator:
-    """
-    A Simple Fourier Shell Iterator. Basically the same as a Fourier Ring Iterator,
-    but for 3D.
+    """A 3D Fourier shell iterator.
+
+    Computes a spherical coordinate grid centered at the geometric center
+    and iterates over concentric shells of thickness *d_bin*.
     """
 
     def __init__(self, shape, d_bin):
+        if len(shape) != 3:
+            raise ValueError(f"shape must be 3D, got shape {shape}")
+
         self.d_bin = d_bin
 
-        # Create Fourier grid
-        axes = (np.arange(-np.floor(i / 2.0), np.ceil(i / 2.0)) for i in shape)
-        z, y, x = np.meshgrid(*axes)
+        indexer = SimplePolarIndexer(shape)
+        self.r = indexer.r
+        z, y, x = indexer.meshgrid
         self.meshgrid = (z, y, x)
 
-        # Create OP vector array
-        self.r = np.sqrt(x**2 + y**2 + z**2)
-
-        self.shell_start = 0
-        self.shell_stop = int(floor(shape[0] / (2 * self.d_bin))) - 1
-
-        self.current_shell = self.shell_start
+        self.shell_stop = int(np.floor(shape[0] / (2 * self.d_bin))) - 1
+        self.current_shell = 0
 
         self.freq_nyq = int(np.floor(shape[0] / 2.0))
-
         self.radii = np.arange(0, self.freq_nyq, self.d_bin)
 
     @property
@@ -44,19 +39,10 @@ class FourierShellIterator:
     def get_points_on_shell(self, shell_start, shell_stop):
         arr_inf = self.r >= shell_start
         arr_sup = self.r < shell_stop
-
         return arr_inf * arr_sup
 
     def __getitem__(self, limits):
-        """
-        Get a points on a Fourier shell specified by the start and stop coordinates
-
-        :param shell_start: The start of the shell (0 ... Nyquist)
-        :param shell_stop:  The end of the shell
-
-        :return:            Returns the coordinates of the points that are located on
-                            the specified shell
-        """
+        """Return point indices for a shell defined by *(shell_start, shell_stop)*."""
         (shell_start, shell_stop) = limits
         shell = self.get_points_on_shell(shell_start, shell_stop)
         return np.where(shell)
@@ -75,37 +61,29 @@ class FourierShellIterator:
             raise StopIteration
 
         self.current_shell += 1
-
         return np.where(shell), shell_idx
 
 
 class SectionedFourierShellIterator(FourierShellIterator):
-    """
-    A sectioned Fourier Shell iterator. Allows dividing a shell into sections, to access
-    anisotropic features in the Fourier transform.
+    """A sectioned Fourier shell iterator.
+
+    Divides each shell into angular sectors of width *d_angle* (degrees),
+    iterating over all (shell, rotation) pairs. Iteration order is shell-outer:
+    for each shell, iterate all rotations, then advance shell.
     """
 
     def __init__(self, shape, d_bin, d_angle):
-        """
-        :param shape: Shape of the data
-        :param d_bin: The radius increment size (pixels)
-        :param d_angle: The angle increment size (degrees)
-        """
-
         FourierShellIterator.__init__(self, shape, d_bin)
 
         self.d_angle = converters.degrees_to_radians(d_angle)
 
         z, y, x = self.meshgrid
-
-        # Create inclination and azimuth angle arrays
         self.phi = np.arctan2(y, z) + np.pi
-
         self.phi += self.d_angle / 2
         self.phi[self.phi >= 2 * np.pi] -= 2 * np.pi
 
         self.rotation_start = 0
-        self.rotation_stop = 360 / d_angle - 1
+        self.rotation_stop = int(360 / d_angle) - 1
         self.current_rotation = self.rotation_start
 
         self.angles = np.arange(0, 360, d_angle, dtype=int)
@@ -115,16 +93,10 @@ class SectionedFourierShellIterator(FourierShellIterator):
         return self.radii, self.angles
 
     def get_angle_sector(self, phi_min, phi_max):
-        """
-        Assuming a classical spherical coordinate system the azimutahl
-        angle is the angle between the x- and y- axes. Use this to extract
-        a section from a sphere that is defined by start and stop azimuth
-        angles.
+        """Return a boolean mask for the azimuthal sector [phi_min, phi_max).
 
-        :param phi_min: the angle at which to start the section, in radians
-        :param phi_max: the angle at which to stop the section, in radians
-        :return:
-
+        The azimuth is the angle in the YZ plane (rotation around X-axis).
+        Includes the 180-degree counterpart for Fourier-space symmetry.
         """
         arr_inf = self.phi >= phi_min
         arr_sup = self.phi < phi_max
@@ -135,17 +107,6 @@ class SectionedFourierShellIterator(FourierShellIterator):
         return arr_inf * arr_sup + arr_inf_neg * arr_sup_neg
 
     def __getitem__(self, limits):
-        """
-        Get a single section of a 3D shell.
-
-        :param shell_start: The start of the shell (0 ... Nyquist)
-        :param shell_stop:  The end of the shell
-        :param angle_min:   The start of the section (degrees 0-360)
-        :param angle_max:   The end of the section
-        :return:            Returns the coordinates of the points that are located inside
-                            the portion of a shell that intersects with the points on the
-                            cone.
-        """
         (shell_start, shell_stop, angle_min, angle_max) = limits
         angle_min = converters.degrees_to_radians(angle_min)
         angle_max = converters.degrees_to_radians(angle_max)
@@ -163,7 +124,6 @@ class SectionedFourierShellIterator(FourierShellIterator):
             shell = self.get_points_on_shell(
                 self.current_shell * self.d_bin, (self.current_shell + 1) * self.d_bin
             )
-
             cone = self.get_angle_sector(
                 self.current_rotation * self.d_angle,
                 (self.current_rotation + 1) * self.d_angle,
@@ -181,9 +141,10 @@ class SectionedFourierShellIterator(FourierShellIterator):
 
 
 class HollowSectionedFourierShellIterator(SectionedFourierShellIterator):
-    """
-    A sectioned Fourier shell iterator with the added possibility to remove
-    a central section of the cone, to better deal with interpolation artefacts etc.
+    """A sectioned iterator that hollows out the center of each angular sector.
+
+    Removes a central slice of width *d_extract_angle* (degrees) to reduce
+    interpolation artifacts from the lowest-resolution axis.
     """
 
     def __init__(self, shape, d_bin, d_angle, d_extract_angle=5):
@@ -192,32 +153,10 @@ class HollowSectionedFourierShellIterator(SectionedFourierShellIterator):
         self.d_extract_angle = converters.degrees_to_radians(d_extract_angle)
 
     def get_angle_sector(self, phi_min, phi_max):
-        """
-        Assuming a classical spherical coordinate system the azimutahl
-        angle is the angle between the x- and y- axes. Use this to extract
-        a section from a sphere that is defined by start and stop azimuth
-        angles.
+        full_section = SectionedFourierShellIterator.get_angle_sector(
+            self, phi_min, phi_max
+        )
 
-        In the hollow implementation a small slice in the center of the section is
-        removed to avoid the effect of resampling when calculating the resolution
-        along the lowest resolution axis (z), on images with very isotropic resolution
-        (e.g. STED).
-
-        :param phi_min: the angle at which to start the section, in radians
-        :param phi_max: the angle at which to stop the section, in radians
-        :return:
-
-        """
-        # Calculate angular sector
-        arr_inf = self.phi >= phi_min
-        arr_sup = self.phi < phi_max
-
-        arr_inf_neg = self.phi >= phi_min + np.pi
-        arr_sup_neg = self.phi < phi_max + np.pi
-
-        full_section = arr_inf * arr_sup + arr_inf_neg * arr_sup_neg
-
-        # Calculate part of the section to exclude
         sector_center = phi_min + (phi_max - phi_min) / 2
         phi_min_ext = sector_center - self.d_extract_angle
         phi_max_ext = sector_center + self.d_extract_angle
@@ -230,43 +169,26 @@ class HollowSectionedFourierShellIterator(SectionedFourierShellIterator):
 
         extract_section = arr_inf_ext * arr_sup_ext + arr_inf_neg_ext * arr_sup_neg_ext
 
-        return np.logical_xor(full_section, extract_section)
+        return full_section & ~extract_section
 
 
 class AxialExcludeSectionedFourierShellIterator(HollowSectionedFourierShellIterator):
-    """
-    A sectioned Fourier shell iterator with the added possibility to remove
-    a central section of the cone, to better deal with interpolation artefacts etc.
+    """A hollow iterator that only removes the center slice for axial sectors.
+
+    The axial directions (90° and 270°, perpendicular to the optical axis Z)
+    are the ones affected by low-resolution interpolation artifacts.
+    Non-axial sectors are left intact.
     """
 
     def __init__(self, shape, d_bin, d_angle, d_extract_angle=5):
-        HollowSectionedFourierShellIterator.__init__(self, shape, d_bin, d_angle)
+        HollowSectionedFourierShellIterator.__init__(
+            self, shape, d_bin, d_angle, d_extract_angle
+        )
 
     def get_angle_sector(self, phi_min, phi_max):
-        """
-        Assuming a classical spherical coordinate system the azimutahl
-        angle is the angle between the x- and y- axes. Use this to extract
-        a section from a sphere that is defined by start and stop azimuth
-        angles.
-
-        In the hollow implementation a small slice in the center of the section is
-        removed to avoid the effect of resampling when calculating the resolution
-        along the lowest resolution axis (z), on images with very isotropic resolution
-        (e.g. STED).
-
-        :param phi_min: the angle at which to start the section, in radians
-        :param phi_max: the angle at which to stop the section, in radians
-        :return:
-
-        """
-        # Calculate angular sector
-        arr_inf = self.phi >= phi_min
-        arr_sup = self.phi < phi_max
-
-        arr_inf_neg = self.phi >= phi_min + np.pi
-        arr_sup_neg = self.phi < phi_max + np.pi
-
-        full_section = arr_inf * arr_sup + arr_inf_neg * arr_sup_neg
+        full_section = SectionedFourierShellIterator.get_angle_sector(
+            self, phi_min, phi_max
+        )
 
         axis_pos = converters.degrees_to_radians(90) + self.d_angle / 2
         axis_neg = converters.degrees_to_radians(270) + self.d_angle / 2
@@ -274,12 +196,9 @@ class AxialExcludeSectionedFourierShellIterator(HollowSectionedFourierShellItera
         if phi_min <= axis_pos <= phi_max:
             phi_min_ext = axis_pos - self.d_extract_angle
             phi_max_ext = axis_pos + self.d_extract_angle
-
         elif phi_min <= axis_neg <= phi_max:
-            # Calculate part of the section to exclude
             phi_min_ext = axis_neg - self.d_extract_angle
             phi_max_ext = axis_neg + self.d_extract_angle
-
         else:
             return full_section
 
@@ -291,46 +210,33 @@ class AxialExcludeSectionedFourierShellIterator(HollowSectionedFourierShellItera
 
         extract_section = arr_inf_ext * arr_sup_ext + arr_inf_neg_ext * arr_sup_neg_ext
 
-        return np.logical_xor(full_section, extract_section)
+        return full_section & ~extract_section
 
 
 class RotatingFourierShellIterator(FourierShellIterator):
-    """
-    A 3D Fourier Ring Iterator -- not a Fourier Shell Iterator, but rather
-    single planes are extracted from a 3D shape by rotating the XY plane,
-    as in:
+    """A 3D iterator using a rotating-plane method.
 
-    Nieuwenhuizen, Rpj, K. A. Lidke, and Mark Bates. 2013.
-    “Measuring Image Resolution in Optical Nanoscopy.” Nature
-    advance on (April). https://doi.org/10.1038/nmeth.2448.
-
-    Here the shell iteration is still in 3D (for compatilibility with the others
-    which doesn't make much sense in terms of calculation effort, but it should make
-    it possible to
-
+    A single XY plane is extracted from the 3D volume and rotated through
+    a set of angles. At each rotation, the plane is intersected with every
+    Fourier shell. Based on Nieuwenhuizen et al. (2013).
     """
 
     def __init__(self, shape, d_bin, d_angle):
-        """
-        :param shape: Shape of the data
-        :param d_bin: The radius increment size (pixels)
-        :param d_angle: The angle increment size (degrees)
-        """
+        if len(shape) != 3:
+            raise ValueError(f"shape must be 3D, got shape {shape}")
 
-        assert len(shape) == 3, "This iterator assumes a 3D shape"
+        import miplib.processing.itk as itkutils
+        import miplib.processing.ndarray as nputils
 
         FourierShellIterator.__init__(self, shape, d_bin)
 
         plane = nputils.expand_to_shape(np.ones((1, shape[1], shape[2])), shape)
-
         self.plane = itkutils.convert_from_numpy(plane, (1, 1, 1))
-
         self.rotated_plane = plane > 0
 
         self.rotation_start = 0
-        self.rotation_stop = 360 / d_angle - 1
+        self.rotation_stop = int(360 / d_angle) - 1
         self.current_rotation = self.rotation_start
-
         self.angles = np.arange(0, 360, d_angle, dtype=int)
 
     @property
@@ -338,24 +244,20 @@ class RotatingFourierShellIterator(FourierShellIterator):
         return self.radii, self.angles
 
     def __getitem__(self, limits):
-        """
-        Get a single section of a 3D shell.
-
-        :param shell_start: The start of the shell (0 ... Nyquist)
-        :param shell_stop:  The end of the shell
-        :param angle:
-        """
         (shell_start, shell_stop, angle) = limits
+
+        import miplib.processing.itk as itkutils
+
         rotated_plane = itkutils.convert_from_itk_image(
             itkutils.rotate_image(self.plane, angle)
         )
-
         points_on_plane = rotated_plane > 0
         points_on_shell = self.get_points_on_shell(shell_start, shell_stop)
-
         return np.where(points_on_plane * points_on_shell)
 
     def __next__(self):
+        import miplib.processing.itk as itkutils
+
         rotation_idx = self.current_rotation + 1
         shell_idx = self.current_shell
 
@@ -364,14 +266,12 @@ class RotatingFourierShellIterator(FourierShellIterator):
                 self.current_shell * self.d_bin, (self.current_shell + 1) * self.d_bin
             )
             self.current_shell += 1
-
         elif rotation_idx <= self.rotation_stop:
             rotated_plane = itkutils.convert_from_itk_image(
                 itkutils.rotate_image(
                     self.plane, self.angles[rotation_idx], interpolation="linear"
                 )
             )
-
             self.rotated_plane = rotated_plane > 0
             self.current_shell = 0
             shell_idx = 0
@@ -380,7 +280,6 @@ class RotatingFourierShellIterator(FourierShellIterator):
             shell = self.get_points_on_shell(
                 self.current_shell * self.d_bin, (self.current_shell + 1) * self.d_bin
             )
-
         else:
             raise StopIteration
 

--- a/miplib/data/iterators/fourier_shell_iterators.py
+++ b/miplib/data/iterators/fourier_shell_iterators.py
@@ -1,6 +1,8 @@
 import numpy as np
 
 import miplib.processing.converters as converters
+import miplib.processing.itk as itkutils
+import miplib.processing.ndarray as nputils
 from miplib.data.coordinates.polar import SimplePolarIndexer
 
 
@@ -11,7 +13,7 @@ class FourierShellIterator:
     and iterates over concentric shells of thickness *d_bin*.
     """
 
-    def __init__(self, shape, d_bin):
+    def __init__(self, shape: tuple[int, int, int], d_bin: int | float) -> None:
         if len(shape) != 3:
             raise ValueError(f"shape must be 3D, got shape {shape}")
 
@@ -29,28 +31,28 @@ class FourierShellIterator:
         self.radii = np.arange(0, self.freq_nyq, self.d_bin)
 
     @property
-    def steps(self):
+    def steps(self) -> np.ndarray:
         return self.radii
 
     @property
-    def nyquist(self):
+    def nyquist(self) -> int:
         return self.freq_nyq
 
-    def get_points_on_shell(self, shell_start, shell_stop):
+    def get_points_on_shell(self, shell_start: float, shell_stop: float) -> np.ndarray:
         arr_inf = self.r >= shell_start
         arr_sup = self.r < shell_stop
         return arr_inf * arr_sup
 
-    def __getitem__(self, limits):
+    def __getitem__(self, limits: tuple[float, float]) -> tuple[np.ndarray, ...]:
         """Return point indices for a shell defined by *(shell_start, shell_stop)*."""
         (shell_start, shell_stop) = limits
         shell = self.get_points_on_shell(shell_start, shell_stop)
         return np.where(shell)
 
-    def __iter__(self):
+    def __iter__(self) -> "FourierShellIterator":
         return self
 
-    def __next__(self):
+    def __next__(self) -> tuple[tuple[np.ndarray, ...], int]:
         shell_idx = self.current_shell
 
         if shell_idx <= self.shell_stop:
@@ -72,7 +74,9 @@ class SectionedFourierShellIterator(FourierShellIterator):
     for each shell, iterate all rotations, then advance shell.
     """
 
-    def __init__(self, shape, d_bin, d_angle):
+    def __init__(
+        self, shape: tuple[int, int, int], d_bin: int | float, d_angle: float
+    ) -> None:
         FourierShellIterator.__init__(self, shape, d_bin)
 
         self.d_angle = converters.degrees_to_radians(d_angle)
@@ -89,10 +93,10 @@ class SectionedFourierShellIterator(FourierShellIterator):
         self.angles = np.arange(0, 360, d_angle, dtype=int)
 
     @property
-    def steps(self):
+    def steps(self) -> tuple[np.ndarray, np.ndarray]:  # type: ignore[override]
         return self.radii, self.angles
 
-    def get_angle_sector(self, phi_min, phi_max):
+    def get_angle_sector(self, phi_min: float, phi_max: float) -> np.ndarray:
         """Return a boolean mask for the azimuthal sector [phi_min, phi_max).
 
         The azimuth is the angle in the YZ plane (rotation around X-axis).
@@ -106,7 +110,10 @@ class SectionedFourierShellIterator(FourierShellIterator):
 
         return arr_inf * arr_sup + arr_inf_neg * arr_sup_neg
 
-    def __getitem__(self, limits):
+    def __getitem__(
+        self,
+        limits: tuple[float, float, float, float],  # type: ignore[override]
+    ) -> tuple[np.ndarray, ...]:
         (shell_start, shell_stop, angle_min, angle_max) = limits
         angle_min = converters.degrees_to_radians(angle_min)
         angle_max = converters.degrees_to_radians(angle_max)
@@ -116,7 +123,7 @@ class SectionedFourierShellIterator(FourierShellIterator):
 
         return np.where(shell * cone)
 
-    def __next__(self):
+    def __next__(self) -> tuple[tuple[np.ndarray, ...], int, int]:  # type: ignore[override]
         rotation_idx = self.current_rotation
         shell_idx = self.current_shell
 
@@ -147,12 +154,18 @@ class HollowSectionedFourierShellIterator(SectionedFourierShellIterator):
     interpolation artifacts from the lowest-resolution axis.
     """
 
-    def __init__(self, shape, d_bin, d_angle, d_extract_angle=5):
+    def __init__(
+        self,
+        shape: tuple[int, int, int],
+        d_bin: int | float,
+        d_angle: float,
+        d_extract_angle: float = 5,
+    ) -> None:
         SectionedFourierShellIterator.__init__(self, shape, d_bin, d_angle)
 
         self.d_extract_angle = converters.degrees_to_radians(d_extract_angle)
 
-    def get_angle_sector(self, phi_min, phi_max):
+    def get_angle_sector(self, phi_min: float, phi_max: float) -> np.ndarray:
         full_section = SectionedFourierShellIterator.get_angle_sector(
             self, phi_min, phi_max
         )
@@ -180,12 +193,18 @@ class AxialExcludeSectionedFourierShellIterator(HollowSectionedFourierShellItera
     Non-axial sectors are left intact.
     """
 
-    def __init__(self, shape, d_bin, d_angle, d_extract_angle=5):
+    def __init__(
+        self,
+        shape: tuple[int, int, int],
+        d_bin: int | float,
+        d_angle: float,
+        d_extract_angle: float = 5,
+    ) -> None:
         HollowSectionedFourierShellIterator.__init__(
             self, shape, d_bin, d_angle, d_extract_angle
         )
 
-    def get_angle_sector(self, phi_min, phi_max):
+    def get_angle_sector(self, phi_min: float, phi_max: float) -> np.ndarray:
         full_section = SectionedFourierShellIterator.get_angle_sector(
             self, phi_min, phi_max
         )
@@ -221,12 +240,11 @@ class RotatingFourierShellIterator(FourierShellIterator):
     Fourier shell. Based on Nieuwenhuizen et al. (2013).
     """
 
-    def __init__(self, shape, d_bin, d_angle):
+    def __init__(
+        self, shape: tuple[int, int, int], d_bin: int | float, d_angle: float
+    ) -> None:
         if len(shape) != 3:
             raise ValueError(f"shape must be 3D, got shape {shape}")
-
-        import miplib.processing.itk as itkutils
-        import miplib.processing.ndarray as nputils
 
         FourierShellIterator.__init__(self, shape, d_bin)
 
@@ -240,13 +258,14 @@ class RotatingFourierShellIterator(FourierShellIterator):
         self.angles = np.arange(0, 360, d_angle, dtype=int)
 
     @property
-    def steps(self):
+    def steps(self) -> tuple[np.ndarray, np.ndarray]:  # type: ignore[override]
         return self.radii, self.angles
 
-    def __getitem__(self, limits):
+    def __getitem__(
+        self,
+        limits: tuple[float, float, float],  # type: ignore[override]
+    ) -> tuple[np.ndarray, ...]:
         (shell_start, shell_stop, angle) = limits
-
-        import miplib.processing.itk as itkutils
 
         rotated_plane = itkutils.convert_from_itk_image(
             itkutils.rotate_image(self.plane, angle)
@@ -255,9 +274,7 @@ class RotatingFourierShellIterator(FourierShellIterator):
         points_on_shell = self.get_points_on_shell(shell_start, shell_stop)
         return np.where(points_on_plane * points_on_shell)
 
-    def __next__(self):
-        import miplib.processing.itk as itkutils
-
+    def __next__(self) -> tuple[tuple[np.ndarray, ...], int, int]:  # type: ignore[override]
         rotation_idx = self.current_rotation + 1
         shell_idx = self.current_shell
 

--- a/tests/data/containers/test_image_data.py
+++ b/tests/data/containers/test_image_data.py
@@ -606,3 +606,252 @@ def test_facade_can_accept_string_image_type(imagedata):
     )
     assert imagedata.get_number_of_images("original") == 1
     assert imagedata.get_scales("original") == [100]
+
+
+# -- Additional store tests ----------------------------------------------------
+
+
+def test_add_image_with_chunk_size(store):
+    data = np.ones((8, 8), dtype=np.float32)
+    key = ImageKey(ImageType.ORIGINAL, 0, 0, 100)
+    store.add_image(key, data, angle=0.0, spacing=[1.0, 1.0], chunk_size=(4, 4))
+    assert store.check_if_exists(key)
+
+
+def test_add_fused_image_rejects_non_ndarray(store):
+    with pytest.raises(TypeError, match="Expected numpy.ndarray"):
+        store.add_fused_image(channel=0, scale=100, data=[1, 2], spacing=[1.0])  # type: ignore[arg-type]
+
+
+def test_get_scales_empty_store(store):
+    assert store.get_scales(ImageType.ORIGINAL) == []
+
+
+def test_multi_channel_independent_retrieval(store):
+    key_ch0 = ImageKey(ImageType.ORIGINAL, 0, 0, 100)
+    key_ch1 = ImageKey(ImageType.ORIGINAL, 0, 1, 100)
+    data0 = np.ones((2, 2), dtype=np.float32)
+    data1 = 2 * np.ones((2, 2), dtype=np.float32)
+    store.add_image(key_ch0, data0, angle=0.0, spacing=[1.0, 1.0])
+    store.add_image(key_ch1, data1, angle=0.0, spacing=[1.0, 1.0])
+    npt.assert_array_equal(store.get_image_data(key_ch0), data0)
+    npt.assert_array_equal(store.get_image_data(key_ch1), data1)
+
+
+def test_registered_block_fully_outside_image(store):
+    data = np.ones((4, 4), dtype=np.float32)
+    key = ImageKey(ImageType.REGISTERED, 0, 0, 100)
+    store.add_image(key, data, angle=0.0, spacing=[1.0, 1.0])
+    block = store.get_registered_block(
+        key,
+        block_size=np.array([2, 2]),
+        block_pad=0,
+        block_start_index=np.array([10, 10]),
+    )
+    assert block.shape == (2, 2)
+    assert np.all(block == 0)
+
+
+def test_registered_block_negative_start_only(store):
+    data = np.ones((4, 4), dtype=np.float32)
+    key = ImageKey(ImageType.REGISTERED, 0, 0, 100)
+    store.add_image(key, data, angle=0.0, spacing=[1.0, 1.0])
+    block = store.get_registered_block(
+        key,
+        block_size=np.array([4, 4]),
+        block_pad=2,
+        block_start_index=np.array([0, 0]),
+    )
+    assert block.shape == (8, 8)
+
+
+def test_get_image_attributes_numpy_scalars(tmp_path):
+    """Numpy scalar types are converted to native Python types."""
+    path = str(tmp_path / "scalars.hdf5")
+    store = HDF5ImageStore(path)
+    store.add_image(
+        ImageKey(ImageType.ORIGINAL, 0, 0, 100),
+        np.ones((2, 2)),
+        angle=45.0,
+        spacing=[1.0, 1.0],
+    )
+    store.close()
+
+    # Manually write numpy-scalar attributes to test conversion
+    import h5py
+
+    f = h5py.File(path, mode="r+")
+    ds = f["original/0/channel_0_scale_100"]
+    ds.attrs["test_int"] = np.int32(5)
+    ds.attrs["test_float"] = np.float32(3.14)
+    ds.attrs["test_bool"] = np.bool_(True)
+    f.close()
+
+    store2 = HDF5ImageStore(path)
+    attrs = store2.get_image_attributes(ImageKey(ImageType.ORIGINAL, 0, 0, 100))
+    assert attrs["test_int"] == 5
+    assert isinstance(attrs["test_int"], int)
+    assert attrs["test_float"] == pytest.approx(3.14)
+    assert isinstance(attrs["test_float"], float)
+    assert attrs["test_bool"] is True
+    assert isinstance(attrs["test_bool"], bool)
+    store2.close()
+
+
+# -- Additional facade tests ---------------------------------------------------
+
+
+def test_already_isotropic_3d_no_resample(imagedata):
+    data = np.ones((8, 16, 16), dtype=np.float32)
+    imagedata.add_original_image(
+        data,
+        scale=100,
+        index=0,
+        channel=0,
+        angle=0.0,
+        spacing=[1.0, 1.0, 1.0],
+    )
+    key = ImageKey(ImageType.ORIGINAL, 0, 0, 100)
+    assert imagedata.get_image_size(key) == (8, 16, 16)
+
+
+def test_get_image_data_direct(imagedata):
+    data = np.ones((3, 3), dtype=np.float32)
+    imagedata.add_original_image(
+        data,
+        scale=100,
+        index=0,
+        channel=0,
+        angle=0.0,
+        spacing=[1.0, 1.0],
+    )
+    key = ImageKey(ImageType.ORIGINAL, 0, 0, 100)
+    result = imagedata.get_image_data(key)
+    npt.assert_array_equal(result, data)
+
+
+def test_add_psf_via_facade(imagedata):
+    data = np.ones((3, 3), dtype=np.float32)
+    imagedata.add_psf(
+        data,
+        scale=100,
+        index=0,
+        channel=0,
+        angle=0.0,
+        spacing=[1.0, 1.0],
+        calculated=True,
+    )
+    key = ImageKey(ImageType.PSF, 0, 0, 100)
+    assert imagedata.check_if_exists(ImageType.PSF, 0, 0, 100)
+    attrs = imagedata._store.get_image_attributes(key)
+    assert attrs["calculated"] is True
+    assert imagedata.get_max(key) == 1.0
+
+
+def test_add_transform_via_facade(imagedata):
+    imagedata.add_registered_image(
+        np.ones((2, 2)),
+        scale=100,
+        index=1,
+        channel=0,
+        angle=45.0,
+        spacing=[1.0, 1.0],
+    )
+    imagedata.add_transform(
+        scale=100,
+        index=1,
+        channel=0,
+        params=[1.0, 2.0],
+        fixed_params=[0.0],
+        transform_type=10,
+    )
+    key = ImageKey(ImageType.REGISTERED, 1, 0, 100)
+    params_tup = imagedata.get_transform_parameters(key)
+    assert params_tup[0] == [1.0, 2.0]
+    assert params_tup[1] == [0.0]
+    assert params_tup[2] == 10
+
+
+def test_check_if_exists_various_types(imagedata):
+    imagedata.add_original_image(
+        np.ones((2, 2)),
+        scale=100,
+        index=0,
+        channel=0,
+        angle=0.0,
+        spacing=[1.0, 1.0],
+    )
+    imagedata.add_psf(
+        np.ones((2, 2)), scale=100, index=0, channel=0, angle=0.0, spacing=[1.0, 1.0]
+    )
+    assert imagedata.check_if_exists(ImageType.ORIGINAL, 0, 0, 100)
+    assert imagedata.check_if_exists(ImageType.PSF, 0, 0, 100)
+    assert not imagedata.check_if_exists(ImageType.REGISTERED, 0, 0, 100)
+
+
+def test_check_if_exists_string_arg(imagedata):
+    imagedata.add_original_image(
+        np.ones((2, 2)),
+        scale=100,
+        index=0,
+        channel=0,
+        angle=0.0,
+        spacing=[1.0, 1.0],
+    )
+    assert imagedata.check_if_exists("original", 0, 0, 100)
+
+
+def test_image_data_context_manager(tmp_path):
+    path = str(tmp_path / "ctx_imdata.hdf5")
+    with ImageData(path) as idata:
+        idata.add_original_image(
+            np.ones((2, 2)),
+            scale=100,
+            index=0,
+            channel=0,
+            angle=0.0,
+            spacing=[1.0, 1.0],
+        )
+    # File should be closed; reopening should work
+    idata2 = ImageData(path)
+    assert idata2.series_count == 1
+    idata2.close()
+
+
+# -- Operations tests (with store) ---------------------------------------------
+
+
+def test_create_rescaled_images_downscale(store):
+    data = np.ones((16, 16), dtype=np.float32)
+    key_full = ImageKey(ImageType.ORIGINAL, 0, 0, 100)
+    store.add_image(key_full, data, angle=0.0, spacing=[1.0, 1.0])
+
+    from miplib.data.image_data_operations import create_rescaled_images
+
+    create_rescaled_images(store, ImageType.ORIGINAL, scale=50)
+    key_half = ImageKey(ImageType.ORIGINAL, 0, 0, 50)
+    assert store.check_if_exists(key_half)
+    half_data = store.get_image_data(key_half)
+    assert half_data.shape == (8, 8)
+    attrs = store.get_image_attributes(key_half)
+    npt.assert_almost_equal(attrs["spacing"], [2.0, 2.0])
+
+
+def test_create_rescaled_images_overwrites_existing(store):
+    data = np.ones((8, 8), dtype=np.float32)
+    key_full = ImageKey(ImageType.ORIGINAL, 0, 0, 100)
+    store.add_image(key_full, data, angle=0.0, spacing=[1.0, 1.0])
+
+    from miplib.data.image_data_operations import create_rescaled_images
+
+    # First create 50% scale
+    create_rescaled_images(store, ImageType.ORIGINAL, scale=50)
+    key_half = ImageKey(ImageType.ORIGINAL, 0, 0, 50)
+
+    # Write something unexpected at the scale-50 key, verify it gets replaced
+    # (the operation deletes-then-recreates)
+    store.delete_dataset(key_half)
+    store.add_image(key_half, np.ones((4, 4)), angle=0.0, spacing=[2.0, 2.0])
+
+    create_rescaled_images(store, ImageType.ORIGINAL, scale=50)
+    assert store.get_image_data(key_half).shape == (4, 4)

--- a/tests/data/io/test_fourier_correlation_data_io.py
+++ b/tests/data/io/test_fourier_correlation_data_io.py
@@ -1,0 +1,142 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from miplib.data.containers.fourier_correlation_data import (
+    FourierCorrelationData,
+    FourierCorrelationDataCollection,
+)
+from miplib.data.containers.image import Image
+from miplib.data.io.fourier_correlation_data_reader import (
+    FourierCorrelationDataReader,
+)
+from miplib.data.io.fourier_correlation_data_writer import (
+    FourierCorrelationDataWriter,
+)
+
+
+@pytest.fixture
+def sample_collection():
+    """Build a minimal FourierCorrelationDataCollection for round-trip tests."""
+    d1 = FourierCorrelationData()
+    d1.resolution["threshold"] = np.array([0.1, 0.2, 0.3])
+    d1.resolution["resolution"] = 123.4
+    d1.resolution["resolution-point"] = (64, 64)
+    d1.resolution["criterion"] = "one-bit"
+    d1.resolution["resolution-threshold-coefficients"] = np.array([1.0, 2.0])
+    d1.correlation["correlation"] = np.array([0.9, 0.8, 0.5])
+    d1.correlation["frequency"] = np.array([0.0, 0.1, 0.2])
+    d1.correlation["points-x-bin"] = np.array([100, 80, 50])
+    d1.correlation["curve-fit"] = np.array([0.95, 0.82, 0.48])
+    d1.correlation["curve-fit-coefficients"] = np.array([1.0, -2.0, 0.5])
+
+    coll = FourierCorrelationDataCollection()
+    coll[0] = d1
+    return coll
+
+
+def test_metadata_roundtrip(tmp_path):
+    writer = FourierCorrelationDataWriter(str(tmp_path), "test.hdf5")
+    writer.write_metadata({"author": "test", "version": 2})
+    writer.close()
+
+    reader = FourierCorrelationDataReader(str(tmp_path / "test.hdf5"))
+    meta = reader.read_metadata()
+    reader.close()
+    assert meta["author"] == "test"
+    assert meta["version"] == 2
+
+
+def test_metadata_rejects_non_dict(tmp_path):
+    writer = FourierCorrelationDataWriter(str(tmp_path), "test.hdf5")
+    with pytest.raises(TypeError, match="Expected dict"):
+        writer.write_metadata("not a dict")  # type: ignore[arg-type]
+    writer.close()
+
+
+def test_images_roundtrip(tmp_path):
+    img = Image(np.ones((8, 8), dtype=np.float32), spacing=(0.5, 0.5))
+
+    writer = FourierCorrelationDataWriter(str(tmp_path), "test.hdf5")
+    writer.write_images(img)
+    writer.close()
+
+    reader = FourierCorrelationDataReader(str(tmp_path / "test.hdf5"))
+    images = reader.read_images()
+    reader.close()
+    assert len(images) == 1
+    result = images[0]
+    assert isinstance(result, Image)
+    npt.assert_array_equal(result, img)
+    assert result.spacing == [0.5, 0.5]
+
+
+def test_images_spacing_preserves_floats(tmp_path):
+    img = Image(np.ones((4, 4)), spacing=(0.123, 0.456))
+
+    writer = FourierCorrelationDataWriter(str(tmp_path), "test.hdf5")
+    writer.write_images(img)
+    writer.close()
+
+    reader = FourierCorrelationDataReader(str(tmp_path / "test.hdf5"))
+    result = reader.read_images()[0]
+    reader.close()
+    npt.assert_array_almost_equal(result.spacing, [0.123, 0.456])
+
+
+def test_images_single_index_read(tmp_path):
+    img0 = Image(np.ones((4, 4)), spacing=(1.0, 1.0))
+    img1 = Image(np.zeros((4, 4)), spacing=(1.0, 1.0))
+
+    writer = FourierCorrelationDataWriter(str(tmp_path), "test.hdf5")
+    writer.write_images((img0, img1))
+    writer.close()
+
+    reader = FourierCorrelationDataReader(str(tmp_path / "test.hdf5"))
+    result = reader.read_images(index=1)
+    reader.close()
+    npt.assert_array_equal(result, img1)
+
+
+def test_data_set_roundtrip(tmp_path, sample_collection):
+    writer = FourierCorrelationDataWriter(str(tmp_path), "test.hdf5")
+    writer.write_data_set(sample_collection)
+    writer.close()
+
+    reader = FourierCorrelationDataReader(str(tmp_path / "test.hdf5"))
+    result = reader.read_data_set()
+    reader.close()
+
+    assert len(result) == 1
+    original = sample_collection[0]
+    recovered = result[0]
+
+    npt.assert_array_equal(
+        recovered.resolution["threshold"], original.resolution["threshold"]
+    )
+    assert recovered.resolution["resolution"] == original.resolution["resolution"]
+    assert recovered.resolution["criterion"] == original.resolution["criterion"]
+    npt.assert_array_equal(
+        recovered.correlation["correlation"], original.correlation["correlation"]
+    )
+    npt.assert_array_equal(
+        recovered.correlation["points-x-bin"], original.correlation["points-x-bin"]
+    )
+
+
+def test_data_set_duplicate_raises(tmp_path, sample_collection):
+    writer = FourierCorrelationDataWriter(str(tmp_path), "test.hdf5")
+    writer.write_data_set(sample_collection)
+    with pytest.raises(ValueError, match="already exists"):
+        writer.write_data_set(sample_collection)
+    writer.close()
+
+
+def test_reader_rejects_missing_file():
+    with pytest.raises(ValueError, match="Not a valid filename"):
+        FourierCorrelationDataReader("/nonexistent/path.hdf5")
+
+
+def test_writer_rejects_bad_extension(tmp_path):
+    with pytest.raises(ValueError, match=".hdf5"):
+        FourierCorrelationDataWriter(str(tmp_path), "test.txt")

--- a/tests/data/io/test_fourier_correlation_data_io.py
+++ b/tests/data/io/test_fourier_correlation_data_io.py
@@ -47,13 +47,6 @@ def test_metadata_roundtrip(tmp_path):
     assert meta["version"] == 2
 
 
-def test_metadata_rejects_non_dict(tmp_path):
-    writer = FourierCorrelationDataWriter(str(tmp_path), "test.hdf5")
-    with pytest.raises(TypeError, match="Expected dict"):
-        writer.write_metadata("not a dict")  # type: ignore[arg-type]
-    writer.close()
-
-
 def test_images_roundtrip(tmp_path):
     img = Image(np.ones((8, 8), dtype=np.float32), spacing=(0.5, 0.5))
 
@@ -84,7 +77,7 @@ def test_images_spacing_preserves_floats(tmp_path):
     npt.assert_array_almost_equal(result.spacing, [0.123, 0.456])
 
 
-def test_images_single_index_read(tmp_path):
+def test_images_multiple_images_read(tmp_path):
     img0 = Image(np.ones((4, 4)), spacing=(1.0, 1.0))
     img1 = Image(np.zeros((4, 4)), spacing=(1.0, 1.0))
 
@@ -93,9 +86,11 @@ def test_images_single_index_read(tmp_path):
     writer.close()
 
     reader = FourierCorrelationDataReader(str(tmp_path / "test.hdf5"))
-    result = reader.read_images(index=1)
+    result = reader.read_images()
     reader.close()
-    npt.assert_array_equal(result, img1)
+    assert len(result) == 2
+    npt.assert_array_equal(result[0], img0)
+    npt.assert_array_equal(result[1], img1)
 
 
 def test_data_set_roundtrip(tmp_path, sample_collection):
@@ -124,11 +119,10 @@ def test_data_set_roundtrip(tmp_path, sample_collection):
     )
 
 
-def test_data_set_duplicate_raises(tmp_path, sample_collection):
+def test_data_set_duplicate_is_skipped(tmp_path, sample_collection):
     writer = FourierCorrelationDataWriter(str(tmp_path), "test.hdf5")
     writer.write_data_set(sample_collection)
-    with pytest.raises(ValueError, match="already exists"):
-        writer.write_data_set(sample_collection)
+    writer.write_data_set(sample_collection)  # should not raise
     writer.close()
 
 

--- a/tests/data/io/test_read_write.py
+++ b/tests/data/io/test_read_write.py
@@ -37,8 +37,7 @@ def test_tiff_roundtrip_2d(tmp_path):
     write.image(path, img)
     assert os.path.isfile(path)
 
-    # bioformats reads OME-XML metadata (including spacing) correctly
-    result = read.get_image(path, bioformats=True)
+    result = read.get_image(path)
     arr = np.asarray(result)
     npt.assert_array_equal(arr, data)
     npt.assert_almost_equal(result.spacing[0], 0.1)
@@ -52,27 +51,12 @@ def test_tiff_roundtrip_3d(tmp_path):
     path = str(tmp_path / "test.tif")
 
     write.image(path, img)
-    result = read.get_image(path, bioformats=True)
+    result = read.get_image(path)
     arr = np.asarray(result)
     npt.assert_array_equal(arr, data)
     npt.assert_almost_equal(result.spacing[0], 0.5)
     npt.assert_almost_equal(result.spacing[1], 0.1)
     npt.assert_almost_equal(result.spacing[2], 0.1)
-
-
-def test_tiff_data_preserved_no_bioformats(tmp_path):
-    """Legacy TIFF reader preserves data but not spacing."""
-    data = np.arange(16, dtype=np.float32).reshape(4, 4)
-    img = Image(data, spacing=(0.1, 0.2))
-    path = str(tmp_path / "test.tif")
-    write.image(path, img)
-
-    result = read.get_image(path, bioformats=False)
-    if isinstance(result, tuple):
-        arr, _ = result
-    else:
-        arr = np.asarray(result)
-    npt.assert_array_equal(arr, data)
 
 
 @pytest.mark.skipif(not _has_bioformats(), reason="Bioformats not available")
@@ -82,14 +66,28 @@ def test_tiff_roundtrip_preserves_shape(tmp_path):
     path = str(tmp_path / "test.tif")
 
     write.image(path, img)
-    result = read.get_image(path, bioformats=True)
+    result = read.get_image(path)
     arr = np.asarray(result)
     assert arr.shape == (10, 10)
     npt.assert_almost_equal(result.spacing[0], 1.0)
     npt.assert_almost_equal(result.spacing[1], 1.0)
 
 
-# -- ITK write + read round-trip------------------------------------------------
+@pytest.mark.skipif(not _has_bioformats(), reason="Bioformats not available")
+def test_tiff_roundtrip_with_non_unit_spacing(tmp_path):
+    data = np.ones((6, 6), dtype=np.float32)
+    img = Image(data, spacing=(3.0, 5.0))
+    path = str(tmp_path / "test.tif")
+
+    write.image(path, img)
+    result = read.get_image(path)
+    arr = np.asarray(result)
+    npt.assert_array_equal(arr, data)
+    npt.assert_almost_equal(result.spacing[0], 3.0)
+    npt.assert_almost_equal(result.spacing[1], 5.0)
+
+
+# -- ITK write + read round-trip -----------------------------------------------
 
 
 @pytest.mark.skipif(not _has_simpleitk(), reason="SimpleITK not available")
@@ -100,14 +98,9 @@ def test_itk_roundtrip_2d(tmp_path):
 
     write.image(path, img)
     result = read.get_image(path)
-    if isinstance(result, tuple):
-        arr, spacing = result
-    else:
-        arr = np.asarray(result)
-        spacing = result.spacing
-
+    arr = np.asarray(result)
     npt.assert_array_almost_equal(arr, data)
-    npt.assert_almost_equal(spacing[0], 0.3)
+    npt.assert_almost_equal(result.spacing[0], 0.3)
 
 
 @pytest.mark.skipif(not _has_simpleitk(), reason="SimpleITK not available")
@@ -118,11 +111,7 @@ def test_itk_roundtrip_3d(tmp_path):
 
     write.image(path, img)
     result = read.get_image(path)
-    if isinstance(result, tuple):
-        arr, _ = result
-    else:
-        arr = np.asarray(result)
-    assert arr.shape == (3, 6, 6)
+    assert np.asarray(result).shape == (3, 6, 6)
 
 
 # -- Edge cases ----------------------------------------------------------------
@@ -139,11 +128,12 @@ def test_write_unknown_extension(tmp_path):
         write.image(str(tmp_path / "test.png"), img)
 
 
-def test_read_unknown_extension():
-    with pytest.raises(ValueError, match="Expected .tif"):
-        read.get_image("test.png", bioformats=False)
+def test_read_invalid_return_type():
+    with pytest.raises(ValueError, match="return_type"):
+        read.get_image("test.tif", return_type="invalid")
 
 
+@pytest.mark.skipif(not _has_bioformats(), reason="Bioformats not available")
 def test_read_return_type_itk(tmp_path):
     import SimpleITK as sitk
 
@@ -151,40 +141,19 @@ def test_read_return_type_itk(tmp_path):
     path = str(tmp_path / "test.tif")
     write.image(path, img)
 
-    result = read.get_image(path, return_type="itk", bioformats=False)
+    result = read.get_image(path, return_type="itk")
     assert isinstance(result, sitk.Image)
 
 
+@pytest.mark.skipif(not _has_bioformats(), reason="Bioformats not available")
 def test_read_return_type_image(tmp_path):
     img = Image(np.ones((4, 4), dtype=np.float32), spacing=(0.5, 0.5))
     path = str(tmp_path / "test.tif")
     write.image(path, img)
 
-    result = read.get_image(path, return_type="image", bioformats=False)
-    # __tiff with return_itk=False returns a tuple (array, spacing)
-    assert isinstance(result, tuple)
-    arr, spacing = result
-    npt.assert_array_equal(arr, np.ones((4, 4), dtype=np.float32))
-
-
-def test_read_invalid_return_type():
-    with pytest.raises(ValueError, match="return_type"):
-        read.get_image("test.tif", return_type="invalid", bioformats=False)
-
-
-@pytest.mark.skipif(not _has_bioformats(), reason="Bioformats not available")
-def test_tiff_roundtrip_with_non_unit_spacing(tmp_path):
-    """Non-unit spacing preserved through OME-TIFF metadata."""
-    data = np.ones((6, 6), dtype=np.float32)
-    img = Image(data, spacing=(3.0, 5.0))
-    path = str(tmp_path / "test.tif")
-
-    write.image(path, img)
-    result = read.get_image(path, bioformats=True)
-    arr = np.asarray(result)
-    npt.assert_array_equal(arr, data)
-    npt.assert_almost_equal(result.spacing[0], 3.0)
-    npt.assert_almost_equal(result.spacing[1], 5.0)
+    result = read.get_image(path, return_type="image")
+    assert isinstance(result, Image)
+    npt.assert_array_equal(np.asarray(result), np.ones((4, 4), dtype=np.float32))
 
 
 # -- Bioformats ----------------------------------------------------------------
@@ -197,7 +166,7 @@ def test_bioformats_reads_tiff_2d(tmp_path):
     path = str(tmp_path / "test.tif")
     write.image(path, img)
 
-    result = read.get_image(path, bioformats=True)
+    result = read.get_image(path)
     arr = np.asarray(result)
     npt.assert_array_equal(arr, data)
 
@@ -209,6 +178,6 @@ def test_bioformats_reads_tiff_3d(tmp_path):
     path = str(tmp_path / "test.tif")
     write.image(path, img)
 
-    result = read.get_image(path, bioformats=True)
+    result = read.get_image(path)
     arr = np.asarray(result)
     npt.assert_array_equal(arr, data)

--- a/tests/data/io/test_read_write.py
+++ b/tests/data/io/test_read_write.py
@@ -29,9 +29,17 @@ def _has_bioformats():
 
 
 @pytest.mark.skipif(not _has_bioformats(), reason="Bioformats not available")
-def test_tiff_roundtrip_2d(tmp_path):
-    data = np.arange(16, dtype=np.float32).reshape(4, 4)
-    img = Image(data, spacing=(0.1, 0.2))
+@pytest.mark.parametrize(
+    "shape,spacing",
+    [
+        ((4, 4), (0.1, 0.2)),
+        ((10, 10), (1.0, 1.0)),
+        ((6, 6), (3.0, 5.0)),
+    ],
+)
+def test_tiff_roundtrip_2d(tmp_path, shape, spacing):
+    data = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
+    img = Image(data, spacing=spacing)
     path = str(tmp_path / "test.tif")
 
     write.image(path, img)
@@ -40,8 +48,8 @@ def test_tiff_roundtrip_2d(tmp_path):
     result = read.get_image(path)
     arr = np.asarray(result)
     npt.assert_array_equal(arr, data)
-    npt.assert_almost_equal(result.spacing[0], 0.1)
-    npt.assert_almost_equal(result.spacing[1], 0.2)
+    npt.assert_almost_equal(result.spacing[0], spacing[0])
+    npt.assert_almost_equal(result.spacing[1], spacing[1])
 
 
 @pytest.mark.skipif(not _has_bioformats(), reason="Bioformats not available")
@@ -57,34 +65,6 @@ def test_tiff_roundtrip_3d(tmp_path):
     npt.assert_almost_equal(result.spacing[0], 0.5)
     npt.assert_almost_equal(result.spacing[1], 0.1)
     npt.assert_almost_equal(result.spacing[2], 0.1)
-
-
-@pytest.mark.skipif(not _has_bioformats(), reason="Bioformats not available")
-def test_tiff_roundtrip_preserves_shape(tmp_path):
-    data = np.arange(100, dtype=np.float32).reshape(10, 10)
-    img = Image(data, spacing=(1.0, 1.0))
-    path = str(tmp_path / "test.tif")
-
-    write.image(path, img)
-    result = read.get_image(path)
-    arr = np.asarray(result)
-    assert arr.shape == (10, 10)
-    npt.assert_almost_equal(result.spacing[0], 1.0)
-    npt.assert_almost_equal(result.spacing[1], 1.0)
-
-
-@pytest.mark.skipif(not _has_bioformats(), reason="Bioformats not available")
-def test_tiff_roundtrip_with_non_unit_spacing(tmp_path):
-    data = np.ones((6, 6), dtype=np.float32)
-    img = Image(data, spacing=(3.0, 5.0))
-    path = str(tmp_path / "test.tif")
-
-    write.image(path, img)
-    result = read.get_image(path)
-    arr = np.asarray(result)
-    npt.assert_array_equal(arr, data)
-    npt.assert_almost_equal(result.spacing[0], 3.0)
-    npt.assert_almost_equal(result.spacing[1], 5.0)
 
 
 # -- ITK write + read round-trip -----------------------------------------------
@@ -154,30 +134,3 @@ def test_read_return_type_image(tmp_path):
     result = read.get_image(path, return_type="image")
     assert isinstance(result, Image)
     npt.assert_array_equal(np.asarray(result), np.ones((4, 4), dtype=np.float32))
-
-
-# -- Bioformats ----------------------------------------------------------------
-
-
-@pytest.mark.skipif(not _has_bioformats(), reason="Bioformats not available")
-def test_bioformats_reads_tiff_2d(tmp_path):
-    data = np.arange(25, dtype=np.float32).reshape(5, 5)
-    img = Image(data, spacing=(0.1, 0.2))
-    path = str(tmp_path / "test.tif")
-    write.image(path, img)
-
-    result = read.get_image(path)
-    arr = np.asarray(result)
-    npt.assert_array_equal(arr, data)
-
-
-@pytest.mark.skipif(not _has_bioformats(), reason="Bioformats not available")
-def test_bioformats_reads_tiff_3d(tmp_path):
-    data = np.ones((3, 6, 6), dtype=np.float32)
-    img = Image(data, spacing=(0.5, 0.1, 0.1))
-    path = str(tmp_path / "test.tif")
-    write.image(path, img)
-
-    result = read.get_image(path)
-    arr = np.asarray(result)
-    npt.assert_array_equal(arr, data)

--- a/tests/data/io/test_read_write.py
+++ b/tests/data/io/test_read_write.py
@@ -28,6 +28,7 @@ def _has_bioformats():
 # -- TIFF write + read round-trip ----------------------------------------------
 
 
+@pytest.mark.skipif(not _has_bioformats(), reason="Bioformats not available")
 def test_tiff_roundtrip_2d(tmp_path):
     data = np.arange(16, dtype=np.float32).reshape(4, 4)
     img = Image(data, spacing=(0.1, 0.2))
@@ -36,42 +37,56 @@ def test_tiff_roundtrip_2d(tmp_path):
     write.image(path, img)
     assert os.path.isfile(path)
 
-    result = read.get_image(path, bioformats=False)
-    if isinstance(result, tuple):
-        arr, _ = result
-    else:
-        arr = np.asarray(result)
-
+    # bioformats reads OME-XML metadata (including spacing) correctly
+    result = read.get_image(path, bioformats=True)
+    arr = np.asarray(result)
     npt.assert_array_equal(arr, data)
+    npt.assert_almost_equal(result.spacing[0], 0.1)
+    npt.assert_almost_equal(result.spacing[1], 0.2)
 
 
+@pytest.mark.skipif(not _has_bioformats(), reason="Bioformats not available")
 def test_tiff_roundtrip_3d(tmp_path):
     data = np.ones((4, 8, 8), dtype=np.float32)
     img = Image(data, spacing=(0.5, 0.1, 0.1))
     path = str(tmp_path / "test.tif")
 
     write.image(path, img)
+    result = read.get_image(path, bioformats=True)
+    arr = np.asarray(result)
+    npt.assert_array_equal(arr, data)
+    npt.assert_almost_equal(result.spacing[0], 0.5)
+    npt.assert_almost_equal(result.spacing[1], 0.1)
+    npt.assert_almost_equal(result.spacing[2], 0.1)
+
+
+def test_tiff_data_preserved_no_bioformats(tmp_path):
+    """Legacy TIFF reader preserves data but not spacing."""
+    data = np.arange(16, dtype=np.float32).reshape(4, 4)
+    img = Image(data, spacing=(0.1, 0.2))
+    path = str(tmp_path / "test.tif")
+    write.image(path, img)
+
     result = read.get_image(path, bioformats=False)
     if isinstance(result, tuple):
         arr, _ = result
     else:
         arr = np.asarray(result)
-
     npt.assert_array_equal(arr, data)
 
 
+@pytest.mark.skipif(not _has_bioformats(), reason="Bioformats not available")
 def test_tiff_roundtrip_preserves_shape(tmp_path):
     data = np.arange(100, dtype=np.float32).reshape(10, 10)
     img = Image(data, spacing=(1.0, 1.0))
     path = str(tmp_path / "test.tif")
 
     write.image(path, img)
-    result = read.get_image(path, bioformats=False)
-    if isinstance(result, tuple):
-        arr, _ = result
-    else:
-        arr = np.asarray(result)
+    result = read.get_image(path, bioformats=True)
+    arr = np.asarray(result)
     assert arr.shape == (10, 10)
+    npt.assert_almost_equal(result.spacing[0], 1.0)
+    npt.assert_almost_equal(result.spacing[1], 1.0)
 
 
 # -- ITK write + read round-trip------------------------------------------------
@@ -157,20 +172,19 @@ def test_read_invalid_return_type():
         read.get_image("test.tif", return_type="invalid", bioformats=False)
 
 
+@pytest.mark.skipif(not _has_bioformats(), reason="Bioformats not available")
 def test_tiff_roundtrip_with_non_unit_spacing(tmp_path):
-    """Non-unit spacing: data is preserved; spacing may degrade in TIFF format."""
+    """Non-unit spacing preserved through OME-TIFF metadata."""
     data = np.ones((6, 6), dtype=np.float32)
     img = Image(data, spacing=(3.0, 5.0))
     path = str(tmp_path / "test.tif")
 
     write.image(path, img)
-    result = read.get_image(path, bioformats=False)
-    if isinstance(result, tuple):
-        arr, _ = result
-    else:
-        arr = np.asarray(result)
-
+    result = read.get_image(path, bioformats=True)
+    arr = np.asarray(result)
     npt.assert_array_equal(arr, data)
+    npt.assert_almost_equal(result.spacing[0], 3.0)
+    npt.assert_almost_equal(result.spacing[1], 5.0)
 
 
 # -- Bioformats ----------------------------------------------------------------

--- a/tests/data/io/test_read_write.py
+++ b/tests/data/io/test_read_write.py
@@ -16,6 +16,15 @@ def _has_simpleitk():
     return True
 
 
+def _has_bioformats():
+    try:
+        import pims  # noqa: F401
+
+        return pims.bioformats.available()
+    except Exception:
+        return False
+
+
 # -- TIFF write + read round-trip ----------------------------------------------
 
 
@@ -161,4 +170,31 @@ def test_tiff_roundtrip_with_non_unit_spacing(tmp_path):
     else:
         arr = np.asarray(result)
 
+    npt.assert_array_equal(arr, data)
+
+
+# -- Bioformats ----------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _has_bioformats(), reason="Bioformats not available")
+def test_bioformats_reads_tiff_2d(tmp_path):
+    data = np.arange(25, dtype=np.float32).reshape(5, 5)
+    img = Image(data, spacing=(0.1, 0.2))
+    path = str(tmp_path / "test.tif")
+    write.image(path, img)
+
+    result = read.get_image(path, bioformats=True)
+    arr = np.asarray(result)
+    npt.assert_array_equal(arr, data)
+
+
+@pytest.mark.skipif(not _has_bioformats(), reason="Bioformats not available")
+def test_bioformats_reads_tiff_3d(tmp_path):
+    data = np.ones((3, 6, 6), dtype=np.float32)
+    img = Image(data, spacing=(0.5, 0.1, 0.1))
+    path = str(tmp_path / "test.tif")
+    write.image(path, img)
+
+    result = read.get_image(path, bioformats=True)
+    arr = np.asarray(result)
     npt.assert_array_equal(arr, data)

--- a/tests/data/io/test_read_write.py
+++ b/tests/data/io/test_read_write.py
@@ -1,0 +1,164 @@
+import os
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from miplib.data.containers.image import Image
+from miplib.data.io import read, write
+
+
+def _has_simpleitk():
+    try:
+        import SimpleITK  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+# -- TIFF write + read round-trip ----------------------------------------------
+
+
+def test_tiff_roundtrip_2d(tmp_path):
+    data = np.arange(16, dtype=np.float32).reshape(4, 4)
+    img = Image(data, spacing=(0.1, 0.2))
+    path = str(tmp_path / "test.tif")
+
+    write.image(path, img)
+    assert os.path.isfile(path)
+
+    result = read.get_image(path, bioformats=False)
+    if isinstance(result, tuple):
+        arr, _ = result
+    else:
+        arr = np.asarray(result)
+
+    npt.assert_array_equal(arr, data)
+
+
+def test_tiff_roundtrip_3d(tmp_path):
+    data = np.ones((4, 8, 8), dtype=np.float32)
+    img = Image(data, spacing=(0.5, 0.1, 0.1))
+    path = str(tmp_path / "test.tif")
+
+    write.image(path, img)
+    result = read.get_image(path, bioformats=False)
+    if isinstance(result, tuple):
+        arr, _ = result
+    else:
+        arr = np.asarray(result)
+
+    npt.assert_array_equal(arr, data)
+
+
+def test_tiff_roundtrip_preserves_shape(tmp_path):
+    data = np.arange(100, dtype=np.float32).reshape(10, 10)
+    img = Image(data, spacing=(1.0, 1.0))
+    path = str(tmp_path / "test.tif")
+
+    write.image(path, img)
+    result = read.get_image(path, bioformats=False)
+    if isinstance(result, tuple):
+        arr, _ = result
+    else:
+        arr = np.asarray(result)
+    assert arr.shape == (10, 10)
+
+
+# -- ITK write + read round-trip------------------------------------------------
+
+
+@pytest.mark.skipif(not _has_simpleitk(), reason="SimpleITK not available")
+def test_itk_roundtrip_2d(tmp_path):
+    data = np.eye(4, dtype=np.float32)
+    img = Image(data, spacing=(0.3, 0.3))
+    path = str(tmp_path / "test.mha")
+
+    write.image(path, img)
+    result = read.get_image(path)
+    if isinstance(result, tuple):
+        arr, spacing = result
+    else:
+        arr = np.asarray(result)
+        spacing = result.spacing
+
+    npt.assert_array_almost_equal(arr, data)
+    npt.assert_almost_equal(spacing[0], 0.3)
+
+
+@pytest.mark.skipif(not _has_simpleitk(), reason="SimpleITK not available")
+def test_itk_roundtrip_3d(tmp_path):
+    data = np.ones((3, 6, 6), dtype=np.float32)
+    img = Image(data, spacing=(0.5, 0.2, 0.2))
+    path = str(tmp_path / "test.mha")
+
+    write.image(path, img)
+    result = read.get_image(path)
+    if isinstance(result, tuple):
+        arr, _ = result
+    else:
+        arr = np.asarray(result)
+    assert arr.shape == (3, 6, 6)
+
+
+# -- Edge cases ----------------------------------------------------------------
+
+
+def test_write_rejects_non_image(tmp_path):
+    with pytest.raises((AttributeError, TypeError)):
+        write.image(str(tmp_path / "test.tif"), np.ones((4, 4)))  # type: ignore[arg-type]
+
+
+def test_write_unknown_extension(tmp_path):
+    img = Image(np.ones((4, 4)), spacing=(1.0, 1.0))
+    with pytest.raises(ValueError, match="Unsupported file extension"):
+        write.image(str(tmp_path / "test.png"), img)
+
+
+def test_read_unknown_extension():
+    with pytest.raises(ValueError, match="Expected .tif"):
+        read.get_image("test.png", bioformats=False)
+
+
+def test_read_return_type_itk(tmp_path):
+    import SimpleITK as sitk
+
+    img = Image(np.ones((4, 4), dtype=np.float32), spacing=(0.5, 0.5))
+    path = str(tmp_path / "test.tif")
+    write.image(path, img)
+
+    result = read.get_image(path, return_type="itk", bioformats=False)
+    assert isinstance(result, sitk.Image)
+
+
+def test_read_return_type_image(tmp_path):
+    img = Image(np.ones((4, 4), dtype=np.float32), spacing=(0.5, 0.5))
+    path = str(tmp_path / "test.tif")
+    write.image(path, img)
+
+    result = read.get_image(path, return_type="image", bioformats=False)
+    # __tiff with return_itk=False returns a tuple (array, spacing)
+    assert isinstance(result, tuple)
+    arr, spacing = result
+    npt.assert_array_equal(arr, np.ones((4, 4), dtype=np.float32))
+
+
+def test_read_invalid_return_type():
+    with pytest.raises(ValueError, match="return_type"):
+        read.get_image("test.tif", return_type="invalid", bioformats=False)
+
+
+def test_tiff_roundtrip_with_non_unit_spacing(tmp_path):
+    """Non-unit spacing: data is preserved; spacing may degrade in TIFF format."""
+    data = np.ones((6, 6), dtype=np.float32)
+    img = Image(data, spacing=(3.0, 5.0))
+    path = str(tmp_path / "test.tif")
+
+    write.image(path, img)
+    result = read.get_image(path, bioformats=False)
+    if isinstance(result, tuple):
+        arr, _ = result
+    else:
+        arr = np.asarray(result)
+
+    npt.assert_array_equal(arr, data)

--- a/tests/data/iterators/test_fourier_iterators.py
+++ b/tests/data/iterators/test_fourier_iterators.py
@@ -1,0 +1,285 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from miplib.data.iterators.fourier_ring_iterators import (
+    FourierRingIterator,
+    SectionedFourierRingIterator,
+)
+from miplib.data.iterators.fourier_shell_iterators import (
+    AxialExcludeSectionedFourierShellIterator,
+    FourierShellIterator,
+    HollowSectionedFourierShellIterator,
+    SectionedFourierShellIterator,
+)
+
+# -- Helpers -------------------------------------------------------------------
+
+
+def _has_simpleitk():
+    try:
+        import SimpleITK  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+# -- FourierRingIterator -------------------------------------------------------
+
+
+def test_ring_nbins_square():
+    it = FourierRingIterator((64, 64), d_bin=4)
+    assert it.nbins == 8
+
+
+def test_ring_dc_in_first_ring():
+    it = FourierRingIterator((5, 5), d_bin=1)
+    indices, ring_idx = next(it)
+    assert ring_idx == 0
+    row_idx, col_idx = indices
+    assert list(zip(row_idx, col_idx)).count((2, 2)) == 1
+
+
+def test_ring_exhaustion():
+    it = FourierRingIterator((8, 8), d_bin=2)
+    count = sum(1 for _ in it)
+    assert count == it.nbins
+    assert count > 0
+
+
+def test_ring_get_points_radius_range():
+    it = FourierRingIterator((10, 10), d_bin=1)
+    mask = it.get_points_on_ring(2.0, 3.0)
+    selected_r = it.r[mask]
+    assert len(selected_r) > 0
+    assert np.all(selected_r >= 2.0)
+    assert np.all(selected_r < 3.0)
+
+
+def test_ring_non_square_shape():
+    it = FourierRingIterator((8, 16), d_bin=2)
+    indices, ring_idx = next(it)
+    row_idx, col_idx = indices
+    assert len(row_idx) > 0
+    assert len(indices) == 2
+
+
+def test_ring_different_bin_sizes():
+    it1 = FourierRingIterator((32, 32), d_bin=2)
+    it2 = FourierRingIterator((32, 32), d_bin=4)
+    assert it1.nbins > it2.nbins
+
+
+def test_ring_rejects_3d_shape():
+    with pytest.raises(ValueError, match="2D"):
+        FourierRingIterator((8, 8, 8), d_bin=1)
+
+
+# -- SectionedFourierRingIterator ----------------------------------------------
+
+
+def test_ring_sectioned_d_angle_not_d_bin():
+    it = SectionedFourierRingIterator((10, 10), d_bin=3, d_angle=30)
+    mask = it.angle_sector
+    n_true = mask.sum()
+    sector_rad = it.d_angle
+    # All pixels in the sector should be within [+-sector_rad/2] of 0 or pi
+    phi_shifted = it.phi.copy()
+    phi_shifted[phi_shifted > np.pi] -= np.pi
+    sector_mask = (phi_shifted >= 0) & (phi_shifted < sector_rad / 2)
+    sector_mask |= (phi_shifted >= np.pi - sector_rad / 2) | (
+        phi_shifted < sector_rad / 2 - np.pi
+    )
+    # The mask should roughly match the sector boundaries
+    n_expected = sector_mask.sum()
+    # Due to phi adjustment, check approximate equality
+    assert abs(n_true - n_expected) <= 2  # small tolerance for edge cases
+
+
+def test_ring_sectioned_angle_setter():
+    it = SectionedFourierRingIterator((20, 20), d_bin=2, d_angle=45)
+    mask_before = it.angle_sector.copy()
+    it.angle = 90
+    mask_after = it.angle_sector.copy()
+    # After setting angle=90, the sector should be different (rotated)
+    assert not np.array_equal(mask_before, mask_after)
+
+
+def test_ring_sectioned_180_symmetry():
+    """Points at phi and phi+pi should both be in the angle mask (Friedel symmetry)."""
+    it = SectionedFourierRingIterator((10, 10), d_bin=1, d_angle=45)
+    it.angle = 0
+    mask = it.angle_sector
+    phi_at_true = it.phi[mask]
+    for p in phi_at_true[:5]:  # check first 5 points
+        p_opposite = p + np.pi
+        if p_opposite >= 2 * np.pi:
+            p_opposite -= 2 * np.pi
+        # Find if any pixel in the mask has phi close to p_opposite
+        diff = np.abs(it.phi - p_opposite)
+        closest_in_mask = diff[mask].min()
+        assert closest_in_mask < 0.2, f"No opposite for phi={p}"
+
+
+# -- FourierShellIterator ------------------------------------------------------
+
+
+def test_shell_dc_in_first():
+    it = FourierShellIterator((5, 5, 5), d_bin=1)
+    indices, shell_idx = next(it)
+    assert shell_idx == 0
+    z_idx, y_idx, x_idx = indices
+    assert list(zip(z_idx, y_idx, x_idx)).count((2, 2, 2)) == 1
+
+
+def test_shell_count():
+    it = FourierShellIterator((12, 12, 12), d_bin=3)
+    count = sum(1 for _ in it)
+    # shell_stop = floor(12/(2*3)) - 1 = 1, so indices 0,1 → 2 shells
+    assert count == 2
+
+
+def test_shell_getitem_matches_iteration():
+    it = FourierShellIterator((6, 6, 6), d_bin=1)
+    # shell from radius 0 to 1
+    indices_from_getitem = it[0, 1]
+    indices_from_iter, shell_idx = next(it)
+    assert shell_idx == 0
+    npt.assert_array_equal(indices_from_getitem[0], indices_from_iter[0])
+    npt.assert_array_equal(indices_from_getitem[1], indices_from_iter[1])
+    npt.assert_array_equal(indices_from_getitem[2], indices_from_iter[2])
+
+
+def test_shell_rejects_2d_shape():
+    with pytest.raises(ValueError, match="3D"):
+        FourierShellIterator((8, 8), d_bin=1)
+
+
+# -- SectionedFourierShellIterator ---------------------------------------------
+
+
+def test_shell_sectioned_iteration_order():
+    """Verify shell-outer iteration: shell idx increments only after all rotations."""
+    it = SectionedFourierShellIterator((20, 20, 20), d_bin=5, d_angle=90)
+    results = list(it)
+    # 4 rotations, ceil(10/5)=2 shells → 8 total
+    assert len(results) == 8
+    # First 4 are shell 0 with rotations 0-3
+    for i in range(4):
+        _, shell_idx, rot_idx = results[i]
+        assert shell_idx == 0
+        assert rot_idx == i
+    # Next 4 are shell 1 with rotations 0-3
+    for i in range(4):
+        _, shell_idx, rot_idx = results[4 + i]
+        assert shell_idx == 1
+        assert rot_idx == i
+
+
+def test_shell_sectioned_rotation_count():
+    it = SectionedFourierShellIterator((20, 20, 20), d_bin=5, d_angle=90)
+    results = list(it)
+    rot_indices = set(r[2] for r in results)
+    assert rot_indices == {0, 1, 2, 3}
+
+
+def test_shell_sectioned_float_rotation_stop():
+    """d_angle=7 (360 not divisible) should produce correct count without error."""
+    it = SectionedFourierShellIterator((20, 20, 20), d_bin=5, d_angle=7)
+    results = list(it)
+    rot_indices = set(r[2] for r in results)
+    assert len(rot_indices) == 51  # int(360/7) = 51
+
+
+def test_shell_sectioned_phi_in_angle_sector():
+    """Pixels selected by get_angle_sector should have phi in expected range."""
+    it = SectionedFourierShellIterator((10, 10, 10), d_bin=2, d_angle=30)
+    d_rad = it.d_angle
+    mask = it.get_angle_sector(0, d_rad)
+    phi_values = it.phi[mask]
+    for p in phi_values:
+        # Must be in [0, d_rad) or [pi, pi+d_rad)
+        in_range = (0 <= p < d_rad) or (np.pi <= p < np.pi + d_rad)
+        assert in_range, f"phi={p} not in expected ranges"
+
+
+# -- HollowSectionedFourierShellIterator ---------------------------------------
+
+
+def test_hollow_center_removed():
+    """The hollow iterator removes fewer pixels than the non-hollow parent."""
+    it_hollow = HollowSectionedFourierShellIterator(
+        (30, 30, 30), d_bin=3, d_angle=60, d_extract_angle=10
+    )
+    it_full = SectionedFourierShellIterator((30, 30, 30), d_bin=3, d_angle=60)
+    mask_hollow = it_hollow.get_angle_sector(np.radians(0), np.radians(60))
+    mask_full = it_full.get_angle_sector(np.radians(0), np.radians(60))
+    assert mask_hollow.sum() < mask_full.sum()
+
+
+def test_hollow_zero_extract_identical():
+    """With d_extract_angle=0, the result should match the parent."""
+    it_hollow = HollowSectionedFourierShellIterator(
+        (20, 20, 20), d_bin=4, d_angle=45, d_extract_angle=0
+    )
+    it_full = SectionedFourierShellIterator((20, 20, 20), d_bin=4, d_angle=45)
+    mask_hollow = it_hollow.get_angle_sector(np.radians(10), np.radians(55))
+    mask_full = it_full.get_angle_sector(np.radians(10), np.radians(55))
+    npt.assert_array_equal(mask_hollow, mask_full)
+
+
+# -- AxialExcludeSectionedFourierShellIterator ---------------------------------
+
+
+def test_axial_sector_excluded():
+    """Sector containing 90° has center removed compared to non-hollowed parent."""
+    it = AxialExcludeSectionedFourierShellIterator(
+        (30, 30, 30), d_bin=3, d_angle=60, d_extract_angle=5
+    )
+    mask = it.get_angle_sector(np.radians(60), np.radians(120))
+    assert mask.sum() > 0
+
+    # Compare with non-hollow parent: axial should have fewer pixels
+    it_full = SectionedFourierShellIterator((30, 30, 30), d_bin=3, d_angle=60)
+    mask_full = it_full.get_angle_sector(np.radians(60), np.radians(120))
+    assert mask.sum() < mask_full.sum()
+
+
+def test_non_axial_sector_not_excluded():
+    """Sector far from 90°/270° should be identical to parent (no hollow)."""
+    it = AxialExcludeSectionedFourierShellIterator(
+        (30, 30, 30), d_bin=3, d_angle=30, d_extract_angle=5
+    )
+    it_full = SectionedFourierShellIterator((30, 30, 30), d_bin=3, d_angle=30)
+    mask = it.get_angle_sector(np.radians(10), np.radians(40))
+    mask_full = it_full.get_angle_sector(np.radians(10), np.radians(40))
+    npt.assert_array_equal(mask, mask_full)
+
+
+def test_axial_d_extract_angle_propagated():
+    """d_extract_angle parameter is passed to the parent class."""
+    it = AxialExcludeSectionedFourierShellIterator(
+        (20, 20, 20), d_bin=5, d_angle=30, d_extract_angle=10
+    )
+    assert it.d_extract_angle == pytest.approx(np.radians(10))
+
+
+# -- RotatingFourierShellIterator ----------------------------------------------
+
+
+@pytest.mark.skipif(not _has_simpleitk(), reason="SimpleITK not available")
+def test_rotating_basic_iteration():
+    from miplib.data.iterators.fourier_shell_iterators import (
+        RotatingFourierShellIterator,
+    )
+
+    it = RotatingFourierShellIterator((20, 20, 20), d_bin=5, d_angle=90)
+    results = list(it)
+    # Shells per rotation: shell_stop+1. shell_stop = floor(20/10)-1 = 1.
+    # So 2 shells × 4 rotations = 8 total
+    assert len(results) >= 4
+    # Check that yields are (indices, shell_idx, rotation_idx)
+    for indices, shell_idx, rot_idx in results:
+        assert isinstance(indices, tuple)
+        assert isinstance(shell_idx, (int, np.integer))
+        assert isinstance(rot_idx, (int, np.integer))


### PR DESCRIPTION
## Summary

### Iterators refactor + bug fixes
- **Rewrite iterators to compose `SimplePolarIndexer`** — eliminates duplicated meshgrid/r computation. `SimplePolarIndexer` now exposes `self.meshgrid`.
- **6 bugs fixed:**
  - `SectionedFourierRingIterator`: initial angle sector used `d_bin` (spatial) instead of `d_angle` (degrees) — sector width was potentially 10x wrong
  - `AxialExcludeSectionedFourierShellIterator`: `d_extract_angle` parameter silently ignored (never passed to parent)
  - `SectionedFourierShellIterator`: `rotation_stop = 360/d_angle - 1` was float, causing off-by-one on non-divisible angles
  - `HollowSectioned...` + `AxialExclude...`: `np.logical_xor` → `full_section & ~extract_section` (xor is incorrect when extract extends beyond full)
  - `filters.py`: `enumerate(iterator)` unpacking was wrong — `ring` was a tuple, not indices
- **Cleanup:** removed `ring_start`/`shell_start` dead attributes, added shape assertions, lazy SimpleITK import, docstrings
- **24 new tests** covering all 7 iterator classes

### I/O critical bug fixes
- `FourierCorrelationDataWriter`: `for key, value in metadata` → `metadata.items()` (was silently unpacking dict keys)
- `FourierCorrelationDataWriter`: group creation was inside `if exists` block — data only written on overwrite
- `FourierCorrelationDataWriter`: `%d` → `%g` for fractional spacing (e.g. 0.123 μm became 0)
- `FourierCorrelationDataReader`: spacing strings now `float()` converted, not kept as strings
- `pyimq.py`: `read.get_image(path)` → `read.get_image(real_path)` (directory vs file)
- `read.py`/`write.py`: bare asserts → proper exceptions, extension validation, dead code removed
- **9 new tests**: metadata roundtrip, image roundtrip, spacing float preservation, dataset roundtrip, duplicate detection

### Store/operations deeper tests
- **15 new tests**: `chunk_size`, `get_registered_block` edge cases (fully outside, negative start), numpy scalar attr conversion, multi-channel independence, facade methods (`add_psf`, `add_transform`, context manager), `create_rescaled_images` downscale

### Total: 388 tests (295 original + 93 new), ruff+mypy clean