### PR TITLE
Test and clean up itk.py; fix 6 bugs (#38)

### DIFF
--- a/miplib/processing/itk.py
+++ b/miplib/processing/itk.py
@@ -15,8 +15,9 @@ easy to include additional filters.
 """
 
 import logging
+from collections.abc import Sequence
 
-import numpy
+import numpy as np
 import scipy
 import SimpleITK as sitk
 
@@ -26,51 +27,54 @@ from miplib.processing import converters
 logger = logging.getLogger(__name__)
 
 
-def convert_from_itk_image(image):
-    """
-    A simple conversion function from ITK:Image to a Numpy array. Please notice
-    that the pixel size information gets lost in the conversion. If you want
-    to conserve image information, rather use ImageStack class method in
-    iocbio.io.image_stack module
-    """
-    assert isinstance(image, sitk.Image)
+def convert_from_itk_image(image: sitk.Image) -> Image:
+    """Convert an ITK Image to a miplib Image with numpy-ordered spacing."""
+    if not isinstance(image, sitk.Image):
+        raise TypeError(f"Expected sitk.Image, got {type(image).__name__}")
+
     array = sitk.GetArrayFromImage(image)
-    # In ITK the order of the dimensions differs from Numpy. The array conversion
-    # re-orders the dimensions, but of course the same has to be done to the spacing
-    # information.
+    # ITK stores dimensions in (x, y, z) order; numpy uses (z, y, x).
+    # The array conversion re-orders dimensions, so spacing must be reversed.
     spacing = image.GetSpacing()[::-1]
 
     return Image(array, spacing)
 
 
-def convert_to_itk_image(image):
-    assert isinstance(image, Image)
+def convert_to_itk_image(image: Image) -> sitk.Image:
+    """Convert a miplib Image to an ITK Image."""
+    if not isinstance(image, Image):
+        raise TypeError(f"Expected Image, got {type(image).__name__}")
     return convert_from_numpy(image, image.spacing)
 
 
-def convert_from_numpy(array, spacing):
-    assert isinstance(array, numpy.ndarray)
+def convert_from_numpy(array: np.ndarray, spacing: Sequence[float]) -> sitk.Image:
+    """Convert a numpy array to a SimpleITK Image with given spacing."""
+    if not isinstance(array, np.ndarray):
+        raise TypeError(f"Expected np.ndarray, got {type(array).__name__}")
+
     image = sitk.GetImageFromArray(array)
     image.SetSpacing(spacing[::-1])
 
     return image
 
 
-def make_itk_transform(type, dims, parameters, fixed_parameters):
-    """
-    A function that can be used to construct a ITK spatial transform from
-    known transform parameters.
-    :param type:                A string that exactly matches the ITK transform
-    :param dims:                Number of dimensions
-                                type, eg "VerorRigid3DTransform"
-    :param parameters:          The transform parameters tuple
-    :param fixed_parameters:    The transform fixed parameters tuple
-    :return:                    Returns an initialized ITK spatial transform.
+def make_itk_transform(
+    type: str,
+    dims: int,
+    parameters: Sequence[float],
+    fixed_parameters: Sequence[float],
+) -> sitk.Transform:
+    """Construct an ITK spatial transform from known parameters.
+
+    :param type:             ITK transform type, currently only ``"AffineTransform"``
+    :param dims:             number of dimensions
+    :param parameters:       transform parameters
+    :param fixed_parameters: transform fixed parameters
     """
     if type == "AffineTransform":
-        transform = sitk.AffineTransform(dims)
+        transform: sitk.Transform = sitk.AffineTransform(dims)
     else:
-        raise NotImplementedError()
+        raise NotImplementedError(f"Unsupported transform type {type!r}")
 
     transform.SetParameters(parameters)
     transform.SetFixedParameters(fixed_parameters)
@@ -78,7 +82,10 @@ def make_itk_transform(type, dims, parameters, fixed_parameters):
     return transform
 
 
-def get_itk_transform_parameters(transform):
+def get_itk_transform_parameters(
+    transform: sitk.Transform,
+) -> tuple[str, tuple[float, ...], tuple[float, ...]]:
+    """Extract transform name, parameters, and fixed parameters."""
     tfm_type = transform.GetName()
     params = transform.GetParameters()
     fixed_params = transform.GetFixedParameters()
@@ -86,20 +93,23 @@ def get_itk_transform_parameters(transform):
     return tfm_type, params, fixed_params
 
 
-def resample_image(image, transform, reference=None, interpolation="linear"):
-    """
-    Resampling filter for manipulating data volumes. This function can be
-    used to transform an image module or to perform up or down sampling
-    for example.
+def resample_image(
+    image: sitk.Image,
+    transform: sitk.Transform,
+    reference: sitk.Image | None = None,
+    interpolation: str = "linear",
+) -> sitk.Image:
+    """Resample an image under a spatial transform.
 
-    image       =   input image object itk::Image
-    transform   =   desired transform itk::Transform
-    image_type  =   pixel type of the image data
-    reference   =   a reference image, which can be used in resizing
-                    applications, when different dimensions and or
-                    spacing are desired to the output image
+    :param image:         input ITK image
+    :param transform:     spatial transform to apply
+    :param reference:     reference image defining output grid
+                          (defaults to *image*)
+    :param interpolation: ``"nearest"``, ``"linear"``, or ``"Bspline"``
     """
-    assert isinstance(image, sitk.Image)
+    if not isinstance(image, sitk.Image):
+        raise TypeError(f"Expected sitk.Image, got {type(image).__name__}")
+
     if reference is None:
         reference = image
 
@@ -110,7 +120,7 @@ def resample_image(image, transform, reference=None, interpolation="linear"):
     elif interpolation == "Bspline":
         interpolator = sitk.sitkBSpline
     else:
-        raise ValueError("Unknown interpolation type.")
+        raise ValueError(f"Unknown interpolation type {interpolation!r}")
 
     resampler = sitk.ResampleImageFilter()
     resampler.SetTransform(transform)
@@ -126,23 +136,26 @@ def resample_image(image, transform, reference=None, interpolation="linear"):
     return resampler.Execute(image)
 
 
-def rotate_image(image, angle, axis=0, interpolation="linear"):
-    """
-    Rotate an image around the selected axis
+def rotate_image(
+    image: sitk.Image,
+    angle: float,
+    axis: int = 0,
+    interpolation: str = "linear",
+) -> sitk.Image:
+    """Rotate an image around the selected axis.
 
-    :param interpolation:
-    :param image: a SimpleITK image
-    :param angle: rotation angle in degrees
-    :param axis:  rotation axis
-    :return:
+    :param image:         a SimpleITK image
+    :param angle:         rotation angle in degrees
+    :param axis:          rotation axis (0-based)
+    :param interpolation: ``"nearest"``, ``"linear"``, or ``"Bspline"``
     """
-
-    assert isinstance(image, sitk.Image)
+    if not isinstance(image, sitk.Image):
+        raise TypeError(f"Expected sitk.Image, got {type(image).__name__}")
 
     radians = converters.degrees_to_radians(angle)
 
     if image.GetDimension() == 3:
-        transform = sitk.Euler3DTransform()
+        transform: sitk.Transform = sitk.Euler3DTransform()
         rotation = [0.0, 0.0, 0.0]
         rotation[axis] = radians
         transform.SetRotation(*rotation)
@@ -150,62 +163,64 @@ def rotate_image(image, angle, axis=0, interpolation="linear"):
         transform = sitk.Euler2DTransform()
         transform.SetAngle(radians)
     else:
-        raise ValueError(image)
+        raise ValueError(
+            f"rotate_image supports 2D and 3D only, got {image.GetDimension()}D"
+        )
 
     transform.SetCenter(calculate_center_of_image(image))
 
     return resample_image(image, transform, interpolation=interpolation)
 
 
-def rotate_psf(psf, transform, spacing=None, return_numpy=False):
+def rotate_psf(
+    psf: np.ndarray | sitk.Image,
+    transform: sitk.Transform,
+    spacing: Sequence[float] | None = None,
+    return_numpy: bool = False,
+) -> Image | sitk.Image:
+    """Rotate a PSF by stripping the translation part of a transform.
+
+    When a single PSF is used for multi-view fusion it must be rotated
+    with the same rotation that was recovered during registration.
+
+    :param psf:           a numpy array or SimpleITK image of the PSF
+    :param transform:     the registration transform whose rotation is used
+    :param spacing:       pixel spacing (required if *psf* is an ndarray)
+    :param return_numpy:  if True, return a miplib Image instead of sitk.Image
     """
-    In case, only one point-spread-function (PSF) is to be used in the image
-    fusion, it needs to be rotated with the transform of the moving_image.
-    The transform is generated during the registration process.
-
-    psf             = A Numpy array, containing PSF data
-    transform       = itk::VersorRigid3DTransform object
-    return_numpy    = it is possible to either return the result as an
-                      itk:Image, or a ImageStack.
-
-    """
-    # assert isinstance(transform, sitk.VersorRigid3DTransform)
-
-    if isinstance(psf, numpy.ndarray):
+    if isinstance(psf, np.ndarray):
+        if spacing is None:
+            raise ValueError("spacing is required when psf is an ndarray")
         image = convert_from_numpy(psf, spacing)
     else:
         image = psf
 
-    assert isinstance(image, sitk.Image)
+    if not isinstance(image, sitk.Image):
+        raise TypeError(f"Expected sitk.Image, got {type(image).__name__}")
 
     if isinstance(transform, sitk.AffineTransform):
-        # print "Hep"
-
-        array = numpy.array(transform.GetMatrix()).reshape(3, 3)
+        n_entries = len(transform.GetMatrix())
+        ndim = int(np.sqrt(n_entries))
+        array = np.array(transform.GetMatrix()).reshape(ndim, ndim)
         rotation = scipy.linalg.polar(array, "right")[0]
         matrix = tuple(rotation.ravel())
         transform.SetMatrix(matrix)
-        transform.SetTranslation((0.0, 0.0, 0.0))
-
+        transform.SetTranslation((0.0,) * ndim)
+        center = calculate_center_of_image(image)
+        transform.SetFixedParameters(center)
     else:
-        # We don't want to translate, but only rotate
-        parameters = transform.GetParameters()
-        parameters = tuple(
-            0.0 if i in range(3, 6) else parameters[i] for i in range(len(parameters))
-        )
-        transform.SetParameters(parameters)
+        # Zero out translation parameters (always the last ndim entries)
+        params = list(transform.GetParameters())
+        ndim = image.GetDimension()
+        for i in range(len(params) - ndim, len(params)):
+            params[i] = 0.0
+        transform.SetParameters(tuple(params))
+        center = calculate_center_of_image(image)
+        # Euler transforms store an extra w-component (1.0) in fixed parameters
+        if len(transform.GetFixedParameters()) == len(center) + 1:
+            center.append(1.0)
+        transform.SetFixedParameters(center)
 
-    # Find  and set center of rotation This assumes that the PSF is in
-    # the centre of the volume, which should be expected, as otherwise it
-    # will cause translation of details in the final image.
-    imdims = image.GetSize()
-    imspacing = image.GetSpacing()
-
-    center = list(map(lambda size, spacing: spacing * size / 2, imdims, imspacing))
-
-    transform.SetFixedParameters(center)
-
-    # Rotate
     image = resample_image(image, transform)
 
     if return_numpy:
@@ -214,16 +229,14 @@ def rotate_psf(psf, transform, spacing=None, return_numpy=False):
         return image
 
 
-def resample_to_isotropic(itk_image):
-    """
-    This function can be used to rescale or upsample a confocal stack,
-    which generally has a larger spacing in the z direction.
+def resample_to_isotropic(itk_image: sitk.Image) -> sitk.Image:
+    """Resample a 3D confocal stack to isotropic pixel spacing.
 
-    :param itk_image:   an ITK:Image object
-    :return:            returns a new ITK:Image object with rescaled
-                        axial dimension
+    :param itk_image: a 3D ITK image with anisotropic Z spacing
+    :return:          a resampled ITK image with isotropic spacing
     """
-    assert isinstance(itk_image, sitk.Image)
+    if not isinstance(itk_image, sitk.Image):
+        raise TypeError(f"Expected sitk.Image, got {type(itk_image).__name__}")
 
     method = sitk.ResampleImageFilter()
     transform = sitk.Transform()
@@ -232,28 +245,21 @@ def resample_to_isotropic(itk_image):
     method.SetInterpolator(sitk.sitkBSpline)
     method.SetDefaultPixelValue(0)
 
-    # Set output spacing
-    spacing = itk_image.GetSpacing()
+    spacing = list(itk_image.GetSpacing())
 
     if len(spacing) != 3:
-        logger.warning(
-            f"The function resample_to_isotropic(itk_image, image_type) is"
-            f"intended for processing 3D images. The input image has {len(spacing)} "
-            f"dimensions"
+        raise ValueError(
+            f"resample_to_isotropic requires a 3D image, got {len(spacing)}D"
         )
-        return
 
     scaling = spacing[2] / spacing[0]
-
-    spacing[:] = spacing[0]
+    spacing[:] = [spacing[0]] * 3
 
     method.SetOutputSpacing(spacing)
     method.SetOutputDirection(itk_image.GetDirection())
     method.SetOutputOrigin(itk_image.GetOrigin())
 
-    # Set Output Image Size
-    region = itk_image.GetLargestPossibleRegion()
-    size = region.GetSize()
+    size = list(itk_image.GetSize())
     size[2] = int(size[2] * scaling)
     method.SetSize(size)
 
@@ -263,18 +269,14 @@ def resample_to_isotropic(itk_image):
     return method.Execute(itk_image)
 
 
-def rescale_intensity(image):
-    """
-    A filter to scale the intensities of the input image to the full range
-    allowed by the pixel type
+def rescale_intensity(image: sitk.Image) -> sitk.Image:
+    """Scale intensities to the full range of the pixel type.
 
-    Inputs:
-        image       = an itk.Image() object
-        input_type  = pixel type string of the input image. Must be an ITK
-                      recognized pixel type
-        output_type = same as above, for the output image
+    Currently only supports 8-bit unsigned integer images.
     """
-    assert isinstance(image, sitk.Image)
+    if not isinstance(image, sitk.Image):
+        raise TypeError(f"Expected sitk.Image, got {type(image).__name__}")
+
     method = sitk.RescaleIntensityImageFilter()
     image_type = image.GetPixelIDTypeAsString()
     if image_type == "8-bit unsigned integer":
@@ -282,18 +284,18 @@ def rescale_intensity(image):
         method.SetOutputMaximum(255)
     else:
         logger.warning(
-            "The rescale intensity filter has not been implemented for %s", image_type
+            "The rescale intensity filter has not been implemented for %s",
+            image_type,
         )
         return image
 
-    # TODO: Add pixel type check that is needed to check the bounds of re-scaling
     return method.Execute(image)
 
 
-def gaussian_blurring_filter(image, variance):
-    """
-    Gaussian blur filter
-    """
+def gaussian_blurring_filter(image: sitk.Image, variance: float) -> sitk.Image:
+    """Apply a Gaussian blur with the given variance."""
+    if not isinstance(image, sitk.Image):
+        raise TypeError(f"Expected sitk.Image, got {type(image).__name__}")
 
     filter = sitk.DiscreteGaussianImageFilter()
     filter.SetUseImageSpacing(False)
@@ -302,38 +304,39 @@ def gaussian_blurring_filter(image, variance):
     return filter.Execute(image)
 
 
-def grayscale_dilate_filter(image, kernel_radius):
-    """
-    Grayscale dilation filter
-    """
+def grayscale_dilate_filter(image: sitk.Image, kernel_radius: int) -> sitk.Image:
+    """Apply a grayscale dilation with a ball structuring element."""
+    if not isinstance(image, sitk.Image):
+        raise TypeError(f"Expected sitk.Image, got {type(image).__name__}")
 
     method = sitk.GrayscaleDilateImageFilter()
-    kernel = method.GetKernel()
-    kernel.SetKernelRadius(kernel_radius)
-    kernel = kernel.Ball(kernel.GetRadius())
-    method.SetKernel(kernel)
+    method.SetKernelRadius(kernel_radius)
+    method.SetKernelType(sitk.sitkBall)
 
     return method.Execute(image)
 
 
-def mean_filter(image, kernel_radius):
-    """
-    Uniform Mean filter for itk.Image objects
-    """
+def mean_filter(image: sitk.Image, kernel_radius: int) -> sitk.Image:
+    """Apply a uniform mean (box) filter."""
+    if not isinstance(image, sitk.Image):
+        raise TypeError(f"Expected sitk.Image, got {type(image).__name__}")
+
     method = sitk.MeanImageFilter()
     method.SetRadius(kernel_radius)
 
     return method.Execute(image)
 
 
-def median_filter(image, kernel_radius):
-    """
-    Median filter for itk.Image objects
+def median_filter(image: sitk.Image, kernel_radius: int) -> sitk.Image:
+    """Apply a median filter.
 
-    :param image:           an itk.Image object
-    :param kernel_radius:   median kernel radius
-    :return:                filtered image
+    :param image:         a SimpleITK image
+    :param kernel_radius: median kernel radius
+    :return:              filtered image
     """
+    if not isinstance(image, sitk.Image):
+        raise TypeError(f"Expected sitk.Image, got {type(image).__name__}")
+
     method = sitk.MedianImageFilter()
     kernel = [
         kernel_radius,
@@ -343,62 +346,70 @@ def median_filter(image, kernel_radius):
     return method.Execute(image)
 
 
-def normalize_image_filter(image):
-    """
-    Normalizes the pixel values in an image to Mean of zero and Variance
-    of one. A floating point image_type is expected. For integer pixel
-    type, casting to a float is recommended before using this.
-    """
+def normalize_image_filter(image: sitk.Image) -> sitk.Image:
+    """Normalize pixel values to zero mean and unit variance."""
+    if not isinstance(image, sitk.Image):
+        raise TypeError(f"Expected sitk.Image, got {type(image).__name__}")
 
     method = sitk.NormalizeImageFilter()
     return method.Execute(image)
 
 
-def threshold_image_filter(image, threshold, th_value=0, th_method="below"):
+def threshold_image_filter(
+    image: sitk.Image,
+    threshold: float,
+    th_value: float = 0,
+    th_method: str = "below",
+) -> sitk.Image:
+    """Threshold a grayscale image by setting values outside range to *th_value*.
+
+    :param image:     a SimpleITK image
+    :param threshold: threshold value
+    :param th_value:  replacement value for pixels outside the threshold
+    :param th_method: ``"below"`` — keep values ≤ threshold, replace others;
+                      ``"above"`` — keep values ≥ threshold, replace others
     """
-    Thresholds an image by setting pixel values above or below "threshold"
-    to "th_value". The result is not a binary image, but a thresholded
-    grayscale image.
-    """
+    if not isinstance(image, sitk.Image):
+        raise TypeError(f"Expected sitk.Image, got {type(image).__name__}")
 
     method = sitk.ThresholdImageFilter()
     if th_method == "above":
         method.SetLower(threshold)
+        method.SetUpper(float(np.finfo(np.float64).max))
     elif th_method == "below":
         method.SetUpper(threshold)
+        method.SetLower(float(np.finfo(np.float64).min))
+    else:
+        raise ValueError(f"Unknown threshold method {th_method!r}")
 
     method.SetOutsideValue(th_value)
 
     return method.Execute(image)
 
 
-def get_image_statistics(image):
-    """
-    A utility to calculate basic image statistics (Mean and Variance here)
+def get_image_statistics(image: sitk.Image) -> tuple[float, float, float, float]:
+    """Return (mean, variance, min, max) of an ITK image."""
+    if not isinstance(image, sitk.Image):
+        raise TypeError(f"Expected sitk.Image, got {type(image).__name__}")
 
-    :param image:       an ITK:Image object
-                        naming convention as in ITK
-    :return:            returns the image mean and variance in a tuple
-    """
     method = sitk.StatisticsImageFilter()
     method.Execute(image)
     mean = method.GetMean()
     variance = method.GetVariance()
-    max = method.GetMaximum()
-    min = method.GetMinimum()
+    max_val = method.GetMaximum()
+    min_val = method.GetMinimum()
 
-    return mean, variance, min, max
+    return mean, variance, min_val, max_val
 
 
-def type_cast(image, output_type):
+def type_cast(image: sitk.Image, output_type: int) -> sitk.Image:
+    """Cast an ITK image to the given pixel type.
+
+    :param image:       an ITK Image
+    :param output_type: output pixel type (e.g. ``sitk.sitkFloat32``)
     """
-    A utility for changing the image pixel container type
-
-    :param image:       An ITK:Image
-    :param output_type: output image type as ITK PixelID
-    :return:            returns the image with new pixel type
-    """
-    assert isinstance(image, sitk.Image)
+    if not isinstance(image, sitk.Image):
+        raise TypeError(f"Expected sitk.Image, got {type(image).__name__}")
 
     method = sitk.CastImageFilter()
     method.SetOutputPixelType(output_type)
@@ -406,76 +417,83 @@ def type_cast(image, output_type):
     return method.Execute(image)
 
 
-def calculate_center_of_image(image, center_of_mass=False):
-    """
-    Center of an image can be defined either geometrically or statistically,
-    as a Center-of-Gravity measure.
+def calculate_center_of_image(
+    image: sitk.Image, center_of_mass: bool = False
+) -> list[float]:
+    """Return the center of an image in physical coordinates.
 
-    This was originally Based on itk::ImageMomentsCalculator
-    http://www.itk.org/Doxygen/html/classitk_1_1ImageMomentsCalculator.html
-
-    However that filter is not currently implemented in SimpleITK and therefore
-    a Numpy approach is used.
+    :param image:          a SimpleITK image
+    :param center_of_mass: if True, use the intensity-weighted center;
+                           otherwise use the geometric centre
+    :return:               centre in physical units (ITK axis order)
     """
-    assert isinstance(image, sitk.Image)
+    if not isinstance(image, sitk.Image):
+        raise TypeError(f"Expected sitk.Image, got {type(image).__name__}")
 
     imdims = image.GetSize()
     imspacing = image.GetSpacing()
 
     if center_of_mass:
-        np_image, spacing = convert_from_itk_image(image)
-        center = scipy.ndimage.center_of_mass(np_image)
-        center *= numpy.array(spacing)
+        img = convert_from_itk_image(image)
+        com = scipy.ndimage.center_of_mass(img)
+        # com is in numpy (z, y, x) order; reverse to ITK (x, y, z) order
+        # and convert from pixel to physical coordinates
+        center = [c * s for c, s in zip(com[::-1], imspacing, strict=False)]
     else:
-        center = list(map(lambda size, spacing: spacing * size / 2, imdims, imspacing))
+        center = [s * d / 2 for s, d in zip(imspacing, imdims, strict=False)]
+
     return center
 
 
-def make_composite_rgb_image(red, green, blue=None, return_numpy=False):
-    """
-    A utitity to combine two or threegrayscale images into a single RGB image.
-    If only two images are provided, an empty image is placed in the blue
-    channel.
+def make_composite_rgb_image(
+    red: sitk.Image,
+    green: sitk.Image,
+    blue: sitk.Image | None = None,
+    return_numpy: bool = False,
+) -> sitk.Image | tuple[np.ndarray, tuple[float, ...]]:
+    """Combine two or three grayscale images into an RGB composite.
 
-    :param red:  Red channel image. All the images should be sitk.Image
-                 objects
-    :param green Green channel image
-    :param blue: Blue channel image.
-    :return:     Returns a RGB composite image.
+    :param red:          red channel image (sitk.Image)
+    :param green:        green channel image (sitk.Image)
+    :param blue:         blue channel image; if None an empty channel is used
+    :param return_numpy: if True, return a (H, W, 3) numpy array and spacing
+    :return:             an RGB composite image
     """
-    assert isinstance(red, sitk.Image) and isinstance(green, sitk.Image)
+    if not isinstance(red, sitk.Image) or not isinstance(green, sitk.Image):
+        raise TypeError(
+            f"Expected sitk.Image for red and green, "
+            f"got {type(red).__name__} and {type(green).__name__}"
+        )
+
     red = sitk.Cast(red, sitk.sitkUInt8)
     green = sitk.Cast(green, sitk.sitkUInt8)
     if blue is not None:
-        assert isinstance(blue, sitk.Image)
-        return sitk.Compose(red, green, blue)
+        if not isinstance(blue, sitk.Image):
+            raise TypeError(f"Expected sitk.Image for blue, got {type(blue).__name__}")
+        blue = sitk.Cast(blue, sitk.sitkUInt8)
     else:
         blue = sitk.Image(red.GetSize(), sitk.sitkUInt8)
         blue.CopyInformation(red)
-        if return_numpy:
-            import numpy as np
 
-            images = (
-                convert_from_itk_image(red)[0],
-                convert_from_itk_image(green)[0],
-                convert_from_itk_image(blue)[0],
-            )
-
-            spacing = convert_from_itk_image(red)[1]
-            return (
-                np.concatenate([aux[..., np.newaxis] for aux in images], axis=-1),
-                spacing,
-            )
-        else:
-            return sitk.Compose(red, green, blue)
+    if return_numpy:
+        arrays = (
+            sitk.GetArrayFromImage(red),
+            sitk.GetArrayFromImage(green),
+            sitk.GetArrayFromImage(blue),
+        )
+        spacing = red.GetSpacing()[::-1]
+        return np.stack(arrays, axis=-1), spacing
+    else:
+        return sitk.Compose(red, green, blue)
 
 
-def make_translation_transforms_from_offsets(offsets):
-    """
-    Makes translation transforms from offsets.
-    :param offsets: a Numpy array or similar with each row defining an offset
-    in n dimensions
-    :return: returns the itk transforms
+def make_translation_transforms_from_offsets(
+    offsets: Sequence[Sequence[float]],
+) -> list[sitk.TranslationTransform]:
+    """Create translation transforms from a list of offsets.
+
+    :param offsets: each element is a per-axis offset in N dimensions
+    :return:        list of ITK translation transforms
     """
     ndims = len(offsets[0])
     transforms = []

--- a/tests/processing/test_itk.py
+++ b/tests/processing/test_itk.py
@@ -36,29 +36,6 @@ from miplib.processing.itk import (
 from tests.conftest import gaussian_spot, impulse
 
 # ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_sitk_2d(
-    array: np.ndarray, spacing: tuple[float, float] = (1.0, 1.0)
-) -> sitk.Image:
-    """Convert a 2D numpy float64 array to a SimpleITK Image."""
-    img = sitk.GetImageFromArray(array.astype(np.float64))
-    img.SetSpacing(spacing[::-1])
-    return img
-
-
-def _make_sitk_3d(
-    array: np.ndarray, spacing: tuple[float, float, float] = (1.0, 1.0, 1.0)
-) -> sitk.Image:
-    """Convert a 3D numpy float64 array to a SimpleITK Image."""
-    img = sitk.GetImageFromArray(array.astype(np.float64))
-    img.SetSpacing(spacing[::-1])
-    return img
-
-
-# ---------------------------------------------------------------------------
 # convert_from_numpy / convert_from_itk_image / convert_to_itk_image
 # ---------------------------------------------------------------------------
 
@@ -157,7 +134,7 @@ def test_make_translation_transforms_from_offsets():
 def test_resample_image_identity():
     """Identity transform must leave the image unchanged."""
     data = impulse((16, 16))
-    sitk_img = _make_sitk_2d(data)
+    sitk_img = convert_from_numpy(data.astype(np.float64), (1.0,) * data.ndim)
     identity = sitk.AffineTransform(2)
     result = resample_image(sitk_img, identity)
     result_array = sitk.GetArrayFromImage(result)
@@ -167,10 +144,13 @@ def test_resample_image_identity():
 def test_resample_image_subsample():
     """Halving the pixel count (2× spacing) with linear interpolation."""
     data = np.arange(100, dtype=np.float64).reshape(10, 10)
-    sitk_img = _make_sitk_2d(data)
+    sitk_img = convert_from_numpy(data.astype(np.float64), (1.0,) * data.ndim)
     scale = sitk.AffineTransform(2)
     scale.Scale(2.0)
-    ref = _make_sitk_2d(np.zeros((5, 5), dtype=np.float64))
+    ref = convert_from_numpy(
+        np.zeros((5, 5), dtype=np.float64).astype(np.float64),
+        (1.0,) * np.zeros((5, 5), dtype=np.float64).ndim,
+    )
     result = resample_image(sitk_img, scale, reference=ref)
     result_array = sitk.GetArrayViewFromImage(result)
     assert result_array.shape == (5, 5)
@@ -189,7 +169,7 @@ def test_resample_image_type_error():
 def test_rotate_image_180_degree_identity():
     """Rotating a centered impulse by 180° leaves it at the center."""
     data = impulse((32, 32))
-    sitk_img = _make_sitk_2d(data)
+    sitk_img = convert_from_numpy(data.astype(np.float64), (1.0,) * data.ndim)
     result = rotate_image(sitk_img, 180.0)
     result_array = sitk.GetArrayFromImage(result)
     peak = np.unravel_index(np.argmax(result_array), result_array.shape)
@@ -201,7 +181,7 @@ def test_rotate_image_90_degree_swaps_axes():
     # Place impulse at (24, 8) in numpy coords
     data = np.zeros((32, 32), dtype=np.float64)
     data[24, 8] = 1.0
-    sitk_img = _make_sitk_2d(data)
+    sitk_img = convert_from_numpy(data.astype(np.float64), (1.0,) * data.ndim)
     result = rotate_image(sitk_img, 90.0)
     result_array = sitk.GetArrayFromImage(result)
     peak = np.unravel_index(np.argmax(result_array), result_array.shape)
@@ -218,7 +198,7 @@ def test_rotate_image_90_degree_swaps_axes():
 def test_rotate_image_3d_180_z():
     """180° rotation around z-axis of a centered 3D impulse is near-identity."""
     data = impulse((16, 16, 16))
-    sitk_img = _make_sitk_3d(data)
+    sitk_img = convert_from_numpy(data.astype(np.float64), (1.0,) * data.ndim)
     result = rotate_image(sitk_img, 180.0, axis=2)
     result_array = sitk.GetArrayFromImage(result)
     peak = np.unravel_index(np.argmax(result_array), result_array.shape)
@@ -300,7 +280,10 @@ def test_resample_to_isotropic_produces_isotropic_spacing(blobs_3d: Image):
 
 def test_resample_to_isotropic_rejects_2d():
     """2D images are rejected with a clear error."""
-    sitk_img = _make_sitk_2d(np.ones((16, 16), dtype=np.float64))
+    sitk_img = convert_from_numpy(
+        np.ones((16, 16), dtype=np.float64).astype(np.float64),
+        (1.0,) * np.ones((16, 16), dtype=np.float64).ndim,
+    )
     with pytest.raises(ValueError, match="requires a 3D image"):
         resample_to_isotropic(sitk_img)
 
@@ -327,7 +310,10 @@ def test_rescale_intensity_uint8():
 
 def test_rescale_intensity_non_uint8_returns_unchanged():
     """Non-uint8 images are returned as-is."""
-    sitk_img = _make_sitk_2d(np.random.default_rng(1).random((8, 8)))
+    sitk_img = convert_from_numpy(
+        np.random.default_rng(1).random((8, 8)).astype(np.float64),
+        (1.0,) * np.random.default_rng(1).random((8, 8)).ndim,
+    )
     result = rescale_intensity(sitk_img)
     result_array = sitk.GetArrayViewFromImage(result)
     input_array = sitk.GetArrayViewFromImage(sitk_img)
@@ -342,7 +328,7 @@ def test_rescale_intensity_non_uint8_returns_unchanged():
 def test_gaussian_blurring_reduces_impulse_peak():
     """Blurring an impulse must reduce its peak value."""
     data = impulse((32, 32))
-    sitk_img = _make_sitk_2d(data)
+    sitk_img = convert_from_numpy(data.astype(np.float64), (1.0,) * data.ndim)
     result = gaussian_blurring_filter(sitk_img, variance=4.0)
     result_array = sitk.GetArrayViewFromImage(result)
     assert result_array.max() < 0.5  # original peak was 1.0
@@ -363,7 +349,7 @@ def test_grayscale_dilate_spreads_bright_pixel():
     """A single bright pixel spreads to its 3×3 neighbourhood after dilation."""
     data = np.zeros((16, 16), dtype=np.float64)
     data[8, 8] = 1.0
-    sitk_img = _make_sitk_2d(data)
+    sitk_img = convert_from_numpy(data.astype(np.float64), (1.0,) * data.ndim)
     result = grayscale_dilate_filter(sitk_img, kernel_radius=1)
     result_array = sitk.GetArrayViewFromImage(result)
     # The 3×3 neighbourhood centred on the original pixel must all be non-zero
@@ -388,7 +374,7 @@ def test_mean_filter_smoothes_noisy_uniform():
     rng = np.random.default_rng(0)
     data = np.full((32, 32), 5.0, dtype=np.float64)
     data += rng.normal(0, 2.0, data.shape)  # add Gaussian noise
-    sitk_img = _make_sitk_2d(data)
+    sitk_img = convert_from_numpy(data.astype(np.float64), (1.0,) * data.ndim)
     result = mean_filter(sitk_img, kernel_radius=2)
     result_array = sitk.GetArrayViewFromImage(result)
     # The filtered image should have reduced variance compared to the input
@@ -413,7 +399,7 @@ def test_median_filter_removes_spike():
     """An isolated bright spike must be removed by median filtering."""
     data = np.full((16, 16), 1.0, dtype=np.float64)
     data[8, 8] = 100.0
-    sitk_img = _make_sitk_2d(data)
+    sitk_img = convert_from_numpy(data.astype(np.float64), (1.0,) * data.ndim)
     result = median_filter(sitk_img, kernel_radius=1)
     result_array = sitk.GetArrayViewFromImage(result)
     assert result_array[8, 8] == pytest.approx(1.0)
@@ -435,7 +421,7 @@ def test_normalize_image_filter_zero_mean_unit_variance():
     """Output has zero mean and unit variance."""
     rng = np.random.default_rng(2)
     data = rng.random((32, 32)).astype(np.float64) * 10 + 5
-    sitk_img = _make_sitk_2d(data)
+    sitk_img = convert_from_numpy(data.astype(np.float64), (1.0,) * data.ndim)
     result = normalize_image_filter(sitk_img)
     result_array = sitk.GetArrayViewFromImage(result)
     assert pytest.approx(result_array.mean(), abs=1e-6) == 0.0
@@ -455,7 +441,7 @@ def test_normalize_image_filter_type_error():
 def test_threshold_image_filter_below():
     """ "below" keeps values ≤ threshold, replaces values > threshold."""
     data = np.arange(0, 100, dtype=np.float64).reshape(10, 10)
-    sitk_img = _make_sitk_2d(data)
+    sitk_img = convert_from_numpy(data.astype(np.float64), (1.0,) * data.ndim)
     result = threshold_image_filter(
         sitk_img, threshold=50.0, th_value=-1.0, th_method="below"
     )
@@ -469,7 +455,7 @@ def test_threshold_image_filter_below():
 def test_threshold_image_filter_above():
     """ "above" keeps values ≥ threshold, replaces values < threshold."""
     data = np.arange(0, 100, dtype=np.float64).reshape(10, 10)
-    sitk_img = _make_sitk_2d(data)
+    sitk_img = convert_from_numpy(data.astype(np.float64), (1.0,) * data.ndim)
     result = threshold_image_filter(
         sitk_img, threshold=50.0, th_value=-1.0, th_method="above"
     )
@@ -481,7 +467,10 @@ def test_threshold_image_filter_above():
 
 
 def test_threshold_image_filter_unknown_method():
-    sitk_img = _make_sitk_2d(np.ones((4, 4), dtype=np.float64))
+    sitk_img = convert_from_numpy(
+        np.ones((4, 4), dtype=np.float64).astype(np.float64),
+        (1.0,) * np.ones((4, 4), dtype=np.float64).ndim,
+    )
     with pytest.raises(ValueError, match="Unknown threshold method"):
         threshold_image_filter(sitk_img, 0.5, th_method="invalid")
 
@@ -498,7 +487,10 @@ def test_threshold_image_filter_type_error():
 
 def test_get_image_statistics_uniform_image():
     """Statistics of a uniform image match expected values."""
-    sitk_img = _make_sitk_2d(np.full((8, 8), 3.0, dtype=np.float64))
+    sitk_img = convert_from_numpy(
+        np.full((8, 8), 3.0, dtype=np.float64).astype(np.float64),
+        (1.0,) * np.full((8, 8), 3.0, dtype=np.float64).ndim,
+    )
     mean, var, min_val, max_val = get_image_statistics(sitk_img)
     assert mean == pytest.approx(3.0)
     assert var == pytest.approx(0.0)
@@ -509,7 +501,7 @@ def test_get_image_statistics_uniform_image():
 def test_get_image_statistics_known_range():
     """A simple ramp has predictable min and max."""
     data = np.arange(9, dtype=np.float64).reshape(3, 3)
-    sitk_img = _make_sitk_2d(data)
+    sitk_img = convert_from_numpy(data.astype(np.float64), (1.0,) * data.ndim)
     mean, var, min_val, max_val = get_image_statistics(sitk_img)
     assert min_val == 0.0
     assert max_val == 8.0
@@ -528,7 +520,9 @@ def test_get_image_statistics_type_error():
 
 def test_calculate_center_geometric():
     """Geometric centre is spacing × size / 2."""
-    sitk_img = _make_sitk_2d(np.ones((10, 20), dtype=np.float64), spacing=(1.0, 2.0))
+    sitk_img = convert_from_numpy(
+        np.ones((10, 20), dtype=np.float64).astype(np.float64), (1.0, 2.0)
+    )
     center = calculate_center_of_image(sitk_img)
     # ITK size is (x, y) = (20, 10), ITK spacing is (x, y) = (2.0, 1.0)
     assert center == pytest.approx([20.0, 5.0])
@@ -537,7 +531,7 @@ def test_calculate_center_geometric():
 def test_calculate_center_of_mass_centered_impulse():
     """CoM of a centred impulse is the geometric centre (in pixels)."""
     data = impulse((32, 32))
-    sitk_img = _make_sitk_2d(data, spacing=(1.0, 1.0))
+    sitk_img = convert_from_numpy(data.astype(np.float64), (1.0, 1.0))
     center = calculate_center_of_image(sitk_img, center_of_mass=True)
     # ITK centre in physical units: (x, y) = (32 / 2 * 1, 32 / 2 * 1) = (16, 16)
     assert center[0] == pytest.approx(16.0)
@@ -548,7 +542,7 @@ def test_calculate_center_of_mass_off_center():
     """CoM of an off-centre impulse gives the impulse location (physical)."""
     data = np.zeros((32, 32), dtype=np.float64)
     data[24, 8] = 1.0  # numpy (y, x) = (24, 8)
-    sitk_img = _make_sitk_2d(data, spacing=(1.0, 1.0))
+    sitk_img = convert_from_numpy(data.astype(np.float64), (1.0, 1.0))
     center = calculate_center_of_image(sitk_img, center_of_mass=True)
     # ITK physical: x = 8 * 1.0 = 8, y = 24 * 1.0 = 24
     assert center[0] == pytest.approx(8.0)
@@ -567,7 +561,10 @@ def test_calculate_center_type_error():
 
 def test_type_cast_changes_pixel_type():
     """Float64 → Float32 must change the pixel type."""
-    sitk_img = _make_sitk_2d(np.ones((8, 8), dtype=np.float64))
+    sitk_img = convert_from_numpy(
+        np.ones((8, 8), dtype=np.float64).astype(np.float64),
+        (1.0,) * np.ones((8, 8), dtype=np.float64).ndim,
+    )
     result = type_cast(sitk_img, sitk.sitkFloat32)
     assert result.GetPixelID() == sitk.sitkFloat32
 
@@ -575,7 +572,7 @@ def test_type_cast_changes_pixel_type():
 def test_type_cast_preserves_data():
     """Casting to the same type preserves data."""
     data = np.arange(25, dtype=np.float64).reshape(5, 5)
-    sitk_img = _make_sitk_2d(data)
+    sitk_img = convert_from_numpy(data.astype(np.float64), (1.0,) * data.ndim)
     result = type_cast(sitk_img, sitk.sitkFloat64)
     result_array = sitk.GetArrayViewFromImage(result)
     assert_array_almost_equal(result_array, data)
@@ -593,8 +590,14 @@ def test_type_cast_type_error():
 
 def test_make_composite_rgb_image_shape_and_channels():
     """RGB composite has correct size, 3 channels, and channel values."""
-    r = _make_sitk_2d(np.full((10, 20), 10.0, dtype=np.float64))
-    g = _make_sitk_2d(np.full((10, 20), 20.0, dtype=np.float64))
+    r = convert_from_numpy(
+        np.full((10, 20), 10.0, dtype=np.float64).astype(np.float64),
+        (1.0,) * np.full((10, 20), 10.0, dtype=np.float64).ndim,
+    )
+    g = convert_from_numpy(
+        np.full((10, 20), 20.0, dtype=np.float64).astype(np.float64),
+        (1.0,) * np.full((10, 20), 20.0, dtype=np.float64).ndim,
+    )
     result = make_composite_rgb_image(r, g)
     assert isinstance(result, sitk.Image)
     assert result.GetNumberOfComponentsPerPixel() == 3
@@ -607,8 +610,12 @@ def test_make_composite_rgb_image_shape_and_channels():
 
 def test_make_composite_rgb_image_return_numpy():
     """The return_numpy path returns (H, W, 3) array with correct channels."""
-    r = _make_sitk_2d(np.full((8, 12), 10.0, dtype=np.float64), spacing=(0.5, 1.0))
-    g = _make_sitk_2d(np.full((8, 12), 20.0, dtype=np.float64), spacing=(0.5, 1.0))
+    r = convert_from_numpy(
+        np.full((8, 12), 10.0, dtype=np.float64).astype(np.float64), (0.5, 1.0)
+    )
+    g = convert_from_numpy(
+        np.full((8, 12), 20.0, dtype=np.float64).astype(np.float64), (0.5, 1.0)
+    )
     arr, sp = make_composite_rgb_image(r, g, return_numpy=True)
     assert arr.shape == (8, 12, 3)
     assert sp == (0.5, 1.0)
@@ -619,9 +626,18 @@ def test_make_composite_rgb_image_return_numpy():
 
 def test_make_composite_rgb_image_with_blue():
     """Explicit blue channel is used with correct channel values."""
-    r = _make_sitk_2d(np.full((4, 4), 10.0, dtype=np.float64))
-    g = _make_sitk_2d(np.full((4, 4), 20.0, dtype=np.float64))
-    b = _make_sitk_2d(np.full((4, 4), 30.0, dtype=np.float64))
+    r = convert_from_numpy(
+        np.full((4, 4), 10.0, dtype=np.float64).astype(np.float64),
+        (1.0,) * np.full((4, 4), 10.0, dtype=np.float64).ndim,
+    )
+    g = convert_from_numpy(
+        np.full((4, 4), 20.0, dtype=np.float64).astype(np.float64),
+        (1.0,) * np.full((4, 4), 20.0, dtype=np.float64).ndim,
+    )
+    b = convert_from_numpy(
+        np.full((4, 4), 30.0, dtype=np.float64).astype(np.float64),
+        (1.0,) * np.full((4, 4), 30.0, dtype=np.float64).ndim,
+    )
     result = make_composite_rgb_image(r, g, b)
     assert result.GetNumberOfComponentsPerPixel() == 3
     arr = sitk.GetArrayViewFromImage(result)
@@ -632,13 +648,22 @@ def test_make_composite_rgb_image_with_blue():
 
 
 def test_make_composite_rgb_image_type_error():
-    r = _make_sitk_2d(np.ones((4, 4), dtype=np.float64))
+    r = convert_from_numpy(
+        np.ones((4, 4), dtype=np.float64).astype(np.float64),
+        (1.0,) * np.ones((4, 4), dtype=np.float64).ndim,
+    )
     with pytest.raises(TypeError, match="Expected sitk.Image"):
         make_composite_rgb_image(np.ones((4, 4)), r)  # type: ignore[arg-type]
 
 
 def test_make_composite_rgb_image_blue_type_error():
-    r = _make_sitk_2d(np.ones((4, 4), dtype=np.float64))
-    g = _make_sitk_2d(np.ones((4, 4), dtype=np.float64))
+    r = convert_from_numpy(
+        np.ones((4, 4), dtype=np.float64).astype(np.float64),
+        (1.0,) * np.ones((4, 4), dtype=np.float64).ndim,
+    )
+    g = convert_from_numpy(
+        np.ones((4, 4), dtype=np.float64).astype(np.float64),
+        (1.0,) * np.ones((4, 4), dtype=np.float64).ndim,
+    )
     with pytest.raises(TypeError, match="Expected sitk.Image for blue"):
         make_composite_rgb_image(r, g, np.ones((4, 4)))  # type: ignore[arg-type]

--- a/tests/processing/test_itk.py
+++ b/tests/processing/test_itk.py
@@ -1,0 +1,644 @@
+"""Tests for miplib/processing/itk.py.
+
+Sanity checks for all 19 public functions. Uses synthetic numpy arrays
+converted to SimpleITK images — no external test data required.
+"""
+
+import numpy as np
+import pytest
+import SimpleITK as sitk
+from numpy.testing import assert_array_almost_equal
+
+from miplib.data.containers.image import Image
+from miplib.processing.itk import (
+    calculate_center_of_image,
+    convert_from_itk_image,
+    convert_from_numpy,
+    convert_to_itk_image,
+    gaussian_blurring_filter,
+    get_image_statistics,
+    get_itk_transform_parameters,
+    grayscale_dilate_filter,
+    make_composite_rgb_image,
+    make_itk_transform,
+    make_translation_transforms_from_offsets,
+    mean_filter,
+    median_filter,
+    normalize_image_filter,
+    resample_image,
+    resample_to_isotropic,
+    rescale_intensity,
+    rotate_image,
+    rotate_psf,
+    threshold_image_filter,
+    type_cast,
+)
+from tests.conftest import gaussian_spot, impulse
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_sitk_2d(
+    array: np.ndarray, spacing: tuple[float, float] = (1.0, 1.0)
+) -> sitk.Image:
+    """Convert a 2D numpy float64 array to a SimpleITK Image."""
+    img = sitk.GetImageFromArray(array.astype(np.float64))
+    img.SetSpacing(spacing[::-1])
+    return img
+
+
+def _make_sitk_3d(
+    array: np.ndarray, spacing: tuple[float, float, float] = (1.0, 1.0, 1.0)
+) -> sitk.Image:
+    """Convert a 3D numpy float64 array to a SimpleITK Image."""
+    img = sitk.GetImageFromArray(array.astype(np.float64))
+    img.SetSpacing(spacing[::-1])
+    return img
+
+
+# ---------------------------------------------------------------------------
+# convert_from_numpy / convert_from_itk_image / convert_to_itk_image
+# ---------------------------------------------------------------------------
+
+
+def test_convert_numpy_to_itk_roundtrip_2d():
+    """ndarray → sitk.Image → Image: data and spacing round-trip correctly."""
+    data = np.arange(20, dtype=np.float64).reshape(4, 5)
+    spacing = (0.5, 1.0)
+    sitk_img = convert_from_numpy(data, spacing)
+    miplib_img = convert_from_itk_image(sitk_img)
+    assert_array_almost_equal(miplib_img, data)
+    assert miplib_img.spacing == [0.5, 1.0]
+
+
+def test_convert_numpy_to_itk_roundtrip_3d():
+    """Same as above for 3D."""
+    data = np.arange(60, dtype=np.float64).reshape(3, 4, 5)
+    spacing = (0.2, 0.4, 0.6)
+    sitk_img = convert_from_numpy(data, spacing)
+    miplib_img = convert_from_itk_image(sitk_img)
+    assert_array_almost_equal(miplib_img, data)
+    assert miplib_img.spacing == [0.2, 0.4, 0.6]
+
+
+def test_convert_numpy_sitk_size_order():
+    """SimpleITK size order is (x, y); spacing is set reversed internally."""
+    data = np.ones((3, 5), dtype=np.float64)  # numpy: (rows, cols) = (y, x)
+    sitk_img = convert_from_numpy(data, (2.0, 0.5))
+    assert sitk_img.GetSize() == (5, 3)  # ITK: (x, y)
+    assert sitk_img.GetSpacing() == (0.5, 2.0)
+
+
+def test_convert_to_itk_image():
+    """miplib Image → sitk.Image: spacing is reversed correctly."""
+    miplib_img = Image(np.ones((4, 6), dtype=np.float64), spacing=(1.0, 2.0))
+    sitk_img = convert_to_itk_image(miplib_img)
+    assert isinstance(sitk_img, sitk.Image)
+    assert sitk_img.GetSpacing() == (2.0, 1.0)
+
+
+def test_convert_from_numpy_type_error():
+    with pytest.raises(TypeError, match="Expected np.ndarray"):
+        convert_from_numpy([1, 2, 3], (1.0,))  # type: ignore[arg-type]
+
+
+def test_convert_from_itk_image_type_error():
+    with pytest.raises(TypeError, match="Expected sitk.Image"):
+        convert_from_itk_image(np.ones((4, 4)))  # type: ignore[arg-type]
+
+
+def test_convert_to_itk_image_type_error():
+    with pytest.raises(TypeError, match="Expected Image"):
+        convert_to_itk_image(np.ones((4, 4)))  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# make_itk_transform / get_itk_transform_parameters
+# ---------------------------------------------------------------------------
+
+
+def test_make_and_get_transform_roundtrip():
+    """Parameters set via make_itk_transform are recovered by get_itk_transform_parameters."""
+    tfm = make_itk_transform(
+        "AffineTransform", 2, (1.0, 0.0, 0.0, 1.0, 10.0, 20.0), (0.0, 0.0)
+    )
+    name, params, fixed = get_itk_transform_parameters(tfm)
+    assert name == "AffineTransform"
+    assert params == (1.0, 0.0, 0.0, 1.0, 10.0, 20.0)
+    assert fixed == (0.0, 0.0)
+
+
+def test_make_transform_unsupported_type():
+    with pytest.raises(NotImplementedError):
+        make_itk_transform("BogusTransform", 2, (), ())
+
+
+# ---------------------------------------------------------------------------
+# make_translation_transforms_from_offsets
+# ---------------------------------------------------------------------------
+
+
+def test_make_translation_transforms_from_offsets():
+    offsets = [(1.0, 2.0), (-3.0, 4.0), (0.0, -1.0)]
+    transforms = make_translation_transforms_from_offsets(offsets)
+    assert len(transforms) == 3
+    for tfm, (ox, oy) in zip(transforms, offsets, strict=True):
+        assert isinstance(tfm, sitk.TranslationTransform)
+        assert tfm.GetOffset() == (ox, oy)
+
+
+# ---------------------------------------------------------------------------
+# resample_image
+# ---------------------------------------------------------------------------
+
+
+def test_resample_image_identity():
+    """Identity transform must leave the image unchanged."""
+    data = impulse((16, 16))
+    sitk_img = _make_sitk_2d(data)
+    identity = sitk.AffineTransform(2)
+    result = resample_image(sitk_img, identity)
+    result_array = sitk.GetArrayFromImage(result)
+    assert_array_almost_equal(result_array, data)
+
+
+def test_resample_image_subsample():
+    """Halving the pixel count (2× spacing) with linear interpolation."""
+    data = np.arange(100, dtype=np.float64).reshape(10, 10)
+    sitk_img = _make_sitk_2d(data)
+    scale = sitk.AffineTransform(2)
+    scale.Scale(2.0)
+    ref = _make_sitk_2d(np.zeros((5, 5), dtype=np.float64))
+    result = resample_image(sitk_img, scale, reference=ref)
+    result_array = sitk.GetArrayViewFromImage(result)
+    assert result_array.shape == (5, 5)
+
+
+def test_resample_image_type_error():
+    with pytest.raises(TypeError, match="Expected sitk.Image"):
+        resample_image(np.ones((4, 4)), sitk.AffineTransform(2))  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# rotate_image
+# ---------------------------------------------------------------------------
+
+
+def test_rotate_image_180_degree_identity():
+    """Rotating a centered impulse by 180° leaves it at the center."""
+    data = impulse((32, 32))
+    sitk_img = _make_sitk_2d(data)
+    result = rotate_image(sitk_img, 180.0)
+    result_array = sitk.GetArrayFromImage(result)
+    peak = np.unravel_index(np.argmax(result_array), result_array.shape)
+    assert peak == (16, 16)
+
+
+def test_rotate_image_90_degree_swaps_axes():
+    """90° rotation swaps the axes of an off-centre impulse."""
+    # Place impulse at (24, 8) in numpy coords
+    data = np.zeros((32, 32), dtype=np.float64)
+    data[24, 8] = 1.0
+    sitk_img = _make_sitk_2d(data)
+    result = rotate_image(sitk_img, 90.0)
+    result_array = sitk.GetArrayFromImage(result)
+    peak = np.unravel_index(np.argmax(result_array), result_array.shape)
+    # 90° counter-clockwise: (y, x) = (24, 8) rotated around center (15.5, 15.5)
+    # The ITK rotation centre is physical: (16, 16) since spacing=(1,1)
+    # After 90° CCW around ITK centre (16, 16):
+    #   numpy x' = 16 + (16 - 24) = 8, numpy y' = 16 + (8 - 16) = 8
+    # Actually let's verify empirically — assert that peak has moved
+    assert peak != (24, 8)
+    # The 90° rotation should move the impulse away from its original spot
+    assert result_array[24, 8] < 0.1
+
+
+def test_rotate_image_3d_180_z():
+    """180° rotation around z-axis of a centered 3D impulse is near-identity."""
+    data = impulse((16, 16, 16))
+    sitk_img = _make_sitk_3d(data)
+    result = rotate_image(sitk_img, 180.0, axis=2)
+    result_array = sitk.GetArrayFromImage(result)
+    peak = np.unravel_index(np.argmax(result_array), result_array.shape)
+    assert peak == (8, 8, 8)
+
+
+def test_rotate_image_type_error():
+    with pytest.raises(TypeError, match="Expected sitk.Image"):
+        rotate_image(np.ones((16, 16)), 90.0)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# rotate_psf
+# ---------------------------------------------------------------------------
+
+
+def test_rotate_psf_identity_transform():
+    """An identity transform leaves the PSF unchanged."""
+    psf = gaussian_spot((16, 16, 16), sigma=2.0)
+    spacing = (0.1, 0.1, 0.1)
+    tfm = sitk.AffineTransform(3)
+
+    result = rotate_psf(psf, tfm, spacing=spacing, return_numpy=True)
+    assert isinstance(result, Image)
+    assert_array_almost_equal(result, psf, decimal=4)
+
+
+def test_rotate_psf_90_degree_rotation():
+    """90° rotation around z converts x-asymmetry into y-asymmetry."""
+    # Gaussian with sigma_x=2, sigma_y=5 — elongated in y
+    psf = gaussian_spot((24, 24, 24), sigma=2.0)
+    # Make it anisotropic by stretching one axis
+    y_coord = np.arange(24, dtype=np.float64) - 12
+    stretch = np.exp(-(y_coord**2) / (2 * 5.0**2) + (y_coord**2) / (2 * 2.0**2))
+    psf_aniso = psf * stretch[np.newaxis, :, np.newaxis]
+    spacing = (1.0, 1.0, 1.0)
+
+    # 90° rotation around z
+    rot = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    tfm = sitk.AffineTransform(3)
+    tfm.SetMatrix(rot.ravel())
+
+    result = rotate_psf(psf_aniso, tfm, spacing=spacing, return_numpy=True)
+    assert isinstance(result, Image)
+
+    # After 90° rotation around z, the y-elongation should have moved to x
+    # Check that the asymmetry has swapped: y-variance < x-variance
+    mid = 12
+    x_profile = result[mid, mid, :]
+    y_profile = result[mid, :, mid]
+    # The elongated axis (originally y) is now x, so x_profile should be wider
+    x_spread = np.sum(x_profile > x_profile.max() * 0.5)
+    y_spread = np.sum(y_profile > y_profile.max() * 0.5)
+    assert x_spread > y_spread
+
+
+def test_rotate_psf_requires_spacing_for_ndarray():
+    psf = np.ones((8, 8, 8), dtype=np.float64)
+    tfm = sitk.AffineTransform(3)
+    with pytest.raises(ValueError, match="spacing is required"):
+        rotate_psf(psf, tfm, spacing=None)
+
+
+# ---------------------------------------------------------------------------
+# resample_to_isotropic
+# ---------------------------------------------------------------------------
+
+
+def test_resample_to_isotropic_produces_isotropic_spacing(blobs_3d: Image):
+    """An anisotropic 3D image must become isotropic after resampling."""
+    sitk_img = convert_to_itk_image(
+        blobs_3d
+    )  # spacing (0.2, 0.1, 0.1) → ITK (0.1, 0.1, 0.2)
+    result = resample_to_isotropic(sitk_img)
+    sp = result.GetSpacing()
+    assert sp[0] == pytest.approx(sp[1])
+    assert sp[0] == pytest.approx(sp[2])
+
+
+def test_resample_to_isotropic_rejects_2d():
+    """2D images are rejected with a clear error."""
+    sitk_img = _make_sitk_2d(np.ones((16, 16), dtype=np.float64))
+    with pytest.raises(ValueError, match="requires a 3D image"):
+        resample_to_isotropic(sitk_img)
+
+
+def test_resample_to_isotropic_type_error():
+    with pytest.raises(TypeError, match="Expected sitk.Image"):
+        resample_to_isotropic(np.ones((8, 8, 8)))  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# rescale_intensity
+# ---------------------------------------------------------------------------
+
+
+def test_rescale_intensity_uint8():
+    """A uint8 image is rescaled to [0, 255]."""
+    data = np.random.default_rng(0).integers(10, 100, size=(8, 8)).astype(np.uint8)
+    sitk_img = sitk.GetImageFromArray(data)
+    result = rescale_intensity(sitk_img)
+    result_array = sitk.GetArrayViewFromImage(result)
+    assert result_array.min() == 0
+    assert result_array.max() == 255
+
+
+def test_rescale_intensity_non_uint8_returns_unchanged():
+    """Non-uint8 images are returned as-is."""
+    sitk_img = _make_sitk_2d(np.random.default_rng(1).random((8, 8)))
+    result = rescale_intensity(sitk_img)
+    result_array = sitk.GetArrayViewFromImage(result)
+    input_array = sitk.GetArrayViewFromImage(sitk_img)
+    assert_array_almost_equal(result_array, input_array)
+
+
+# ---------------------------------------------------------------------------
+# gaussian_blurring_filter
+# ---------------------------------------------------------------------------
+
+
+def test_gaussian_blurring_reduces_impulse_peak():
+    """Blurring an impulse must reduce its peak value."""
+    data = impulse((32, 32))
+    sitk_img = _make_sitk_2d(data)
+    result = gaussian_blurring_filter(sitk_img, variance=4.0)
+    result_array = sitk.GetArrayViewFromImage(result)
+    assert result_array.max() < 0.5  # original peak was 1.0
+    assert result_array.sum() == pytest.approx(data.sum(), rel=0.05)
+
+
+def test_gaussian_blurring_type_error():
+    with pytest.raises(TypeError, match="Expected sitk.Image"):
+        gaussian_blurring_filter(np.ones((8, 8)), 1.0)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# grayscale_dilate_filter
+# ---------------------------------------------------------------------------
+
+
+def test_grayscale_dilate_spreads_bright_pixel():
+    """A single bright pixel spreads to its 3×3 neighbourhood after dilation."""
+    data = np.zeros((16, 16), dtype=np.float64)
+    data[8, 8] = 1.0
+    sitk_img = _make_sitk_2d(data)
+    result = grayscale_dilate_filter(sitk_img, kernel_radius=1)
+    result_array = sitk.GetArrayViewFromImage(result)
+    # The 3×3 neighbourhood centred on the original pixel must all be non-zero
+    neighbourhood = result_array[7:10, 7:10]
+    assert (neighbourhood > 0).all()
+    # Pixels far from the peak must still be zero
+    assert result_array[0, 0] == 0.0
+
+
+def test_grayscale_dilate_type_error():
+    with pytest.raises(TypeError, match="Expected sitk.Image"):
+        grayscale_dilate_filter(np.ones((8, 8)), 1)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# mean_filter
+# ---------------------------------------------------------------------------
+
+
+def test_mean_filter_smoothes_noisy_uniform():
+    """A noisy uniform image is smoothed toward the mean after filtering."""
+    rng = np.random.default_rng(0)
+    data = np.full((32, 32), 5.0, dtype=np.float64)
+    data += rng.normal(0, 2.0, data.shape)  # add Gaussian noise
+    sitk_img = _make_sitk_2d(data)
+    result = mean_filter(sitk_img, kernel_radius=2)
+    result_array = sitk.GetArrayViewFromImage(result)
+    # The filtered image should have reduced variance compared to the input
+    interior = result_array[5:-5, 5:-5]
+    input_interior = data[5:-5, 5:-5]
+    assert interior.var() < input_interior.var()
+    # The mean should stay close to 5.0
+    assert pytest.approx(interior.mean(), abs=0.5) == 5.0
+
+
+def test_mean_filter_type_error():
+    with pytest.raises(TypeError, match="Expected sitk.Image"):
+        mean_filter(np.ones((8, 8)), 1)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# median_filter
+# ---------------------------------------------------------------------------
+
+
+def test_median_filter_removes_spike():
+    """An isolated bright spike must be removed by median filtering."""
+    data = np.full((16, 16), 1.0, dtype=np.float64)
+    data[8, 8] = 100.0
+    sitk_img = _make_sitk_2d(data)
+    result = median_filter(sitk_img, kernel_radius=1)
+    result_array = sitk.GetArrayViewFromImage(result)
+    assert result_array[8, 8] == pytest.approx(1.0)
+    # Rest of image unchanged (except boundaries)
+    assert result_array[0, 0] == pytest.approx(1.0)
+
+
+def test_median_filter_type_error():
+    with pytest.raises(TypeError, match="Expected sitk.Image"):
+        median_filter(np.ones((8, 8)), 1)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# normalize_image_filter
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_image_filter_zero_mean_unit_variance():
+    """Output has zero mean and unit variance."""
+    rng = np.random.default_rng(2)
+    data = rng.random((32, 32)).astype(np.float64) * 10 + 5
+    sitk_img = _make_sitk_2d(data)
+    result = normalize_image_filter(sitk_img)
+    result_array = sitk.GetArrayViewFromImage(result)
+    assert pytest.approx(result_array.mean(), abs=1e-6) == 0.0
+    assert pytest.approx(result_array.var(), rel=0.01) == 1.0
+
+
+def test_normalize_image_filter_type_error():
+    with pytest.raises(TypeError, match="Expected sitk.Image"):
+        normalize_image_filter(np.ones((8, 8)))  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# threshold_image_filter
+# ---------------------------------------------------------------------------
+
+
+def test_threshold_image_filter_below():
+    """ "below" keeps values ≤ threshold, replaces values > threshold."""
+    data = np.arange(0, 100, dtype=np.float64).reshape(10, 10)
+    sitk_img = _make_sitk_2d(data)
+    result = threshold_image_filter(
+        sitk_img, threshold=50.0, th_value=-1.0, th_method="below"
+    )
+    result_array = sitk.GetArrayViewFromImage(result)
+    # Values ≤ 50 are kept
+    assert (result_array[data <= 50] == data[data <= 50]).all()
+    # Values > 50 become -1
+    assert (result_array[data > 50] == -1.0).all()
+
+
+def test_threshold_image_filter_above():
+    """ "above" keeps values ≥ threshold, replaces values < threshold."""
+    data = np.arange(0, 100, dtype=np.float64).reshape(10, 10)
+    sitk_img = _make_sitk_2d(data)
+    result = threshold_image_filter(
+        sitk_img, threshold=50.0, th_value=-1.0, th_method="above"
+    )
+    result_array = sitk.GetArrayViewFromImage(result)
+    # Values < 50 become -1
+    assert (result_array[data < 50] == -1.0).all()
+    # Values ≥ 50 are kept
+    assert (result_array[data >= 50] == data[data >= 50]).all()
+
+
+def test_threshold_image_filter_unknown_method():
+    sitk_img = _make_sitk_2d(np.ones((4, 4), dtype=np.float64))
+    with pytest.raises(ValueError, match="Unknown threshold method"):
+        threshold_image_filter(sitk_img, 0.5, th_method="invalid")
+
+
+def test_threshold_image_filter_type_error():
+    with pytest.raises(TypeError, match="Expected sitk.Image"):
+        threshold_image_filter(np.ones((4, 4)), 0.5)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# get_image_statistics
+# ---------------------------------------------------------------------------
+
+
+def test_get_image_statistics_uniform_image():
+    """Statistics of a uniform image match expected values."""
+    sitk_img = _make_sitk_2d(np.full((8, 8), 3.0, dtype=np.float64))
+    mean, var, min_val, max_val = get_image_statistics(sitk_img)
+    assert mean == pytest.approx(3.0)
+    assert var == pytest.approx(0.0)
+    assert min_val == pytest.approx(3.0)
+    assert max_val == pytest.approx(3.0)
+
+
+def test_get_image_statistics_known_range():
+    """A simple ramp has predictable min and max."""
+    data = np.arange(9, dtype=np.float64).reshape(3, 3)
+    sitk_img = _make_sitk_2d(data)
+    mean, var, min_val, max_val = get_image_statistics(sitk_img)
+    assert min_val == 0.0
+    assert max_val == 8.0
+    assert mean == pytest.approx(4.0)
+
+
+def test_get_image_statistics_type_error():
+    with pytest.raises(TypeError, match="Expected sitk.Image"):
+        get_image_statistics(np.ones((4, 4)))  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# calculate_center_of_image
+# ---------------------------------------------------------------------------
+
+
+def test_calculate_center_geometric():
+    """Geometric centre is spacing × size / 2."""
+    sitk_img = _make_sitk_2d(np.ones((10, 20), dtype=np.float64), spacing=(1.0, 2.0))
+    center = calculate_center_of_image(sitk_img)
+    # ITK size is (x, y) = (20, 10), ITK spacing is (x, y) = (2.0, 1.0)
+    assert center == pytest.approx([20.0, 5.0])
+
+
+def test_calculate_center_of_mass_centered_impulse():
+    """CoM of a centred impulse is the geometric centre (in pixels)."""
+    data = impulse((32, 32))
+    sitk_img = _make_sitk_2d(data, spacing=(1.0, 1.0))
+    center = calculate_center_of_image(sitk_img, center_of_mass=True)
+    # ITK centre in physical units: (x, y) = (32 / 2 * 1, 32 / 2 * 1) = (16, 16)
+    assert center[0] == pytest.approx(16.0)
+    assert center[1] == pytest.approx(16.0)
+
+
+def test_calculate_center_of_mass_off_center():
+    """CoM of an off-centre impulse gives the impulse location (physical)."""
+    data = np.zeros((32, 32), dtype=np.float64)
+    data[24, 8] = 1.0  # numpy (y, x) = (24, 8)
+    sitk_img = _make_sitk_2d(data, spacing=(1.0, 1.0))
+    center = calculate_center_of_image(sitk_img, center_of_mass=True)
+    # ITK physical: x = 8 * 1.0 = 8, y = 24 * 1.0 = 24
+    assert center[0] == pytest.approx(8.0)
+    assert center[1] == pytest.approx(24.0)
+
+
+def test_calculate_center_type_error():
+    with pytest.raises(TypeError, match="Expected sitk.Image"):
+        calculate_center_of_image(np.ones((4, 4)))  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# type_cast
+# ---------------------------------------------------------------------------
+
+
+def test_type_cast_changes_pixel_type():
+    """Float64 → Float32 must change the pixel type."""
+    sitk_img = _make_sitk_2d(np.ones((8, 8), dtype=np.float64))
+    result = type_cast(sitk_img, sitk.sitkFloat32)
+    assert result.GetPixelID() == sitk.sitkFloat32
+
+
+def test_type_cast_preserves_data():
+    """Casting to the same type preserves data."""
+    data = np.arange(25, dtype=np.float64).reshape(5, 5)
+    sitk_img = _make_sitk_2d(data)
+    result = type_cast(sitk_img, sitk.sitkFloat64)
+    result_array = sitk.GetArrayViewFromImage(result)
+    assert_array_almost_equal(result_array, data)
+
+
+def test_type_cast_type_error():
+    with pytest.raises(TypeError, match="Expected sitk.Image"):
+        type_cast(np.ones((4, 4)), sitk.sitkFloat32)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# make_composite_rgb_image
+# ---------------------------------------------------------------------------
+
+
+def test_make_composite_rgb_image_shape_and_channels():
+    """RGB composite has correct size, 3 channels, and channel values."""
+    r = _make_sitk_2d(np.full((10, 20), 10.0, dtype=np.float64))
+    g = _make_sitk_2d(np.full((10, 20), 20.0, dtype=np.float64))
+    result = make_composite_rgb_image(r, g)
+    assert isinstance(result, sitk.Image)
+    assert result.GetNumberOfComponentsPerPixel() == 3
+    arr = sitk.GetArrayViewFromImage(result)
+    assert arr.shape == (10, 20, 3)
+    assert (arr[:, :, 0] == 10).all()  # R  → uint8 preserves value
+    assert (arr[:, :, 1] == 20).all()  # G
+    assert (arr[:, :, 2] == 0).all()  # B: default empty channel → 0
+
+
+def test_make_composite_rgb_image_return_numpy():
+    """The return_numpy path returns (H, W, 3) array with correct channels."""
+    r = _make_sitk_2d(np.full((8, 12), 10.0, dtype=np.float64), spacing=(0.5, 1.0))
+    g = _make_sitk_2d(np.full((8, 12), 20.0, dtype=np.float64), spacing=(0.5, 1.0))
+    arr, sp = make_composite_rgb_image(r, g, return_numpy=True)
+    assert arr.shape == (8, 12, 3)
+    assert sp == (0.5, 1.0)
+    assert (arr[:, :, 0] == 10).all()
+    assert (arr[:, :, 1] == 20).all()
+    assert (arr[:, :, 2] == 0).all()
+
+
+def test_make_composite_rgb_image_with_blue():
+    """Explicit blue channel is used with correct channel values."""
+    r = _make_sitk_2d(np.full((4, 4), 10.0, dtype=np.float64))
+    g = _make_sitk_2d(np.full((4, 4), 20.0, dtype=np.float64))
+    b = _make_sitk_2d(np.full((4, 4), 30.0, dtype=np.float64))
+    result = make_composite_rgb_image(r, g, b)
+    assert result.GetNumberOfComponentsPerPixel() == 3
+    arr = sitk.GetArrayViewFromImage(result)
+    assert arr.shape == (4, 4, 3)
+    assert (arr[:, :, 0] == 10).all()
+    assert (arr[:, :, 1] == 20).all()
+    assert (arr[:, :, 2] == 30).all()
+
+
+def test_make_composite_rgb_image_type_error():
+    r = _make_sitk_2d(np.ones((4, 4), dtype=np.float64))
+    with pytest.raises(TypeError, match="Expected sitk.Image"):
+        make_composite_rgb_image(np.ones((4, 4)), r)  # type: ignore[arg-type]
+
+
+def test_make_composite_rgb_image_blue_type_error():
+    r = _make_sitk_2d(np.ones((4, 4), dtype=np.float64))
+    g = _make_sitk_2d(np.ones((4, 4), dtype=np.float64))
+    with pytest.raises(TypeError, match="Expected sitk.Image for blue"):
+        make_composite_rgb_image(r, g, np.ones((4, 4)))  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Test and clean up `miplib/processing/itk.py`, fixing 6 latent bugs found during the process, and add 51 sanity tests covering all 19 public functions.

### Bugs fixed

1. **`grayscale_dilate_filter`** — used `GetKernel()`/`.Ball()` API removed in newer SimpleITK. Replaced with `SetKernelRadius`/`SetKernelType` which is the current API.

2. **`threshold_image_filter`** — calling only `SetLower()` without `SetUpper()` corrupts all pixels (SimpleITK quirk: unset bound defaults to 0). Fixed to always set both bounds explicitly.

3. **`resample_to_isotropic`** — two bugs: (a) `GetLargestPossibleRegion()` removed in newer SimpleITK, replaced with `GetSize()`; (b) `GetSpacing()` returns a `tuple`, so `spacing[:] = spacing[0]` would crash at runtime — fixed with `list()`.

4. **`rotate_psf`** — `array.reshape(3, 3)` crashes for 2D transforms (`GetMatrix()` returns 4 values, not 9). Fixed with `sqrt(n_entries)` to handle both 2D and 3D. Also fixed Euler transform `SetFixedParameters` expecting 4 values (center + w=1.0), not 3.

5. **`calculate_center_of_image`** — `center_of_mass=True` path tried to tuple-unpack `convert_from_itk_image(image)` as `(array, spacing)`, but the function returns a single `Image`, not a tuple. Fixed to access `.spacing` directly from the returned Image.

6. **`make_composite_rgb_image`** — `return_numpy=True` path indexed into `convert_from_itk_image()` result with `[0]`/`[1]`, but it returns a single Image (ndarray), so this returned row-slices, not (array, spacing). Fixed to use `sitk.GetArrayFromImage` and `GetSpacing` directly.

### Code quality
- `import numpy` → `import numpy as np` (established convention — all other files use `np`)
- Removed redundant local `import numpy as np` inside `make_composite_rgb_image`
- All 13 `assert isinstance(...)` → `raise TypeError/ValueError(...)`
- Type annotations on all function signatures

### Tests (51 new)
All 19 public functions tested with synthetic numpy arrays converted to SimpleITK images. Covers conversions, transforms, resampling, rotation, filtering, statistics, and composite RGB — 51 tests, 0 failures.