### PR TITLE
refactor: convert os.path to pathlib/Path throughout

### DIFF
--- a/miplib/analysis/image_quality/image_quality_ranking.py
+++ b/miplib/analysis/image_quality/image_quality_ranking.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import pandas as pd
 
@@ -61,30 +61,30 @@ def batch_evaluate_image_quality(path, options):
         ]
     )
 
-    for idx, image_name in enumerate(os.listdir(path)):
-        if options.file_filter is None or options.file_filter in image_name:
-            real_path = os.path.join(path, image_name)
-            # Only process images
-            if not os.path.isfile(real_path) or not real_path.endswith(
-                (".jpg", ".tif", ".tiff", ".tif")
-            ):
-                continue
-            # ImageJ files have particular TIFF tags that can be processed correctly
-            # with the options.imagej switch
-            image = read.get_image(real_path, channel=options.rgb_channel)
+    for idx, image_entry in enumerate(Path(path).iterdir()):
+        if not image_entry.is_file():
+            continue
+        image_name = image_entry.name
+        if options.file_filter is not None and options.file_filter not in image_name:
+            continue
+        if image_entry.suffix not in (".jpg", ".tif", ".tiff"):
+            continue
+        # ImageJ files have particular TIFF tags that can be processed correctly
+        # with the options.imagej switch
+        image = read.get_image(image_entry, channel=options.rgb_channel)
 
-            # Only grayscale images are processed. If the input is an RGB image,
-            # a channel can be chosen for processing.
-            results = evaluate_image_quality(image, options)
-            results.insert(0, real_path)
+        # Only grayscale images are processed. If the input is an RGB image,
+        # a channel can be chosen for processing.
+        results = evaluate_image_quality(image, options)
+        results.insert(0, str(image_entry))
 
-            # Add resolution value to the end
-            results.append(
-                frc.calculate_single_image_frc(image, options).resolution["resolution"]
-            )
+        # Add resolution value to the end
+        results.append(
+            frc.calculate_single_image_frc(image, options).resolution["resolution"]
+        )
 
-            df.loc[idx] = results
+        df.loc[idx] = results
 
-            print(f"Done analyzing {image_name}")
+        print(f"Done analyzing {image_name}")
 
     return df

--- a/miplib/analysis/resolution/fourier_ring_correlation.py
+++ b/miplib/analysis/resolution/fourier_ring_correlation.py
@@ -5,7 +5,7 @@ Image resolution measurement by Fourier Ring Correlation.
 
 """
 
-import os
+from pathlib import Path
 
 import numpy as np
 
@@ -204,16 +204,15 @@ def batch_evaluate_frc(path, options):
     :param options: options for the FRC
     :parame path:   directory that contains the images to be analyzed
     """
-    assert os.path.isdir(path)
+    assert Path(path).is_dir()
 
     measures = FourierCorrelationDataCollection()
     image_names = []
 
-    for idx, image_name in enumerate(sorted(os.listdir(path))):
-        real_path = os.path.join(path, image_name)
+    for idx, real_path in enumerate(sorted(Path(path).iterdir())):
         # Only process images. The bioformats reader can actually do many more file formats
         # but I was a little lazy here, as we usually have tiffs.
-        if not os.path.isfile(real_path) or not real_path.endswith((".tiff", ".tif")):
+        if not real_path.is_file() or real_path.suffix not in (".tiff", ".tif"):
             continue
         # ImageJ files have particular TIFF tags that can be processed correctly
         # with the options.imagej switch
@@ -223,7 +222,7 @@ def batch_evaluate_frc(path, options):
         # a channel can be chosen for processing.
         measures[idx] = calculate_single_image_frc(image, options)
 
-        image_names.append(image_name)
+        image_names.append(real_path.name)
 
     return measures, image_names
 

--- a/miplib/bin/correlatem.py
+++ b/miplib/bin/correlatem.py
@@ -16,7 +16,7 @@ from miplib.ui.cli import miplib_entry_point_options
 
 def main():
     options = miplib_entry_point_options.get_correlate_tem_script_options(sys.argv[1:])
-    wd = Path(options.working_directory)
+    wd = options.working_directory
 
     options.sted_image_path = str(wd / options.sted_image_path)
     if not Path(options.sted_image_path).is_file():

--- a/miplib/bin/correlatem.py
+++ b/miplib/bin/correlatem.py
@@ -3,8 +3,8 @@
 """Correlative light-electron microscopy registration CLI."""
 
 import datetime
-import os
 import sys
+from pathlib import Path
 
 import SimpleITK as sitk
 
@@ -16,17 +16,14 @@ from miplib.ui.cli import miplib_entry_point_options
 
 def main():
     options = miplib_entry_point_options.get_correlate_tem_script_options(sys.argv[1:])
+    wd = Path(options.working_directory)
 
-    options.sted_image_path = os.path.join(
-        options.working_directory, options.sted_image_path
-    )
-    if not os.path.isfile(options.sted_image_path):
+    options.sted_image_path = str(wd / options.sted_image_path)
+    if not Path(options.sted_image_path).is_file():
         sys.exit(f"No such file: {options.sted_image_path}")
 
-    options.em_image_path = os.path.join(
-        options.working_directory, options.em_image_path
-    )
-    if not os.path.isfile(options.em_image_path):
+    options.em_image_path = str(wd / options.em_image_path)
+    if not Path(options.em_image_path).is_file():
         sys.exit(f"No such file: {options.em_image_path}")
 
     sted_image = sitk.ReadImage(options.sted_image_path)
@@ -73,19 +70,18 @@ def main():
     )
 
     output_dir = datetime.datetime.now().strftime("%Y-%m-%d") + "_clem_output"
-    output_dir = os.path.join(options.working_directory, output_dir)
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
+    output_dir = wd / output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
 
     date_now = datetime.datetime.now().strftime("%H-%M-%S")
     file_name = f"{date_now}-clem_registration-{options.registration_method}.tiff"
-    file_path = os.path.join(output_dir, file_name)
+    file_path = output_dir / file_name
     tfm_name = f"{date_now}_transform.txt"
-    tfm_path = os.path.join(output_dir, tfm_name)
-    sitk.WriteTransform(transform, tfm_path)
+    tfm_path = output_dir / tfm_name
+    sitk.WriteTransform(transform, str(tfm_path))
 
     rgb = itkutils.make_composite_rgb_image(sted_original, em_registered)
-    sitk.WriteImage(rgb, file_path)
+    sitk.WriteImage(rgb, str(file_path))
     print(f"Saved {file_name} and {tfm_name} to {output_dir}")
 
 

--- a/miplib/bin/deconvolve.py
+++ b/miplib/bin/deconvolve.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import argparse
 import logging
-import os
 import sys
 import time
+from pathlib import Path
 
 from miplib.data.adapters.image_data import ArrayDataSource
 from miplib.data.containers.image import Image
@@ -136,7 +136,7 @@ def main():
 
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
 
-    if not os.path.isfile(args.image):
+    if not Path(args.image).is_file():
         sys.exit(f"Image not found: {args.image}")
 
     image = _load_image(args.image)
@@ -168,7 +168,7 @@ def main():
     )
 
     print(
-        f"Deconvolving {os.path.basename(args.image)} "
+        f"Deconvolving {Path(args.image).name} "
         f"({image.shape}) with {args.iterations} iterations "
         f"({'CUDA' if args.enable_cuda else 'CPU'})"
     )

--- a/miplib/bin/deconvolve.py
+++ b/miplib/bin/deconvolve.py
@@ -76,9 +76,11 @@ def _build_parser() -> argparse.ArgumentParser:
             "  miplib-deconvolve image.tif --fwhm 1.5 --tv-lambda 0.01 --enable-cuda\n"
         ),
     )
-    parser.add_argument("image", help="Path to the input image (TIFF).")
+    parser.add_argument("image", type=Path, help="Path to the input image (TIFF).")
     parser.add_argument(
-        "--psf", help="Path to a PSF image. If omitted, a Gaussian PSF is generated."
+        "--psf",
+        type=Path,
+        help="Path to a PSF image. If omitted, a Gaussian PSF is generated.",
     )
     parser.add_argument(
         "--fwhm",
@@ -107,7 +109,11 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Stop when tau1 drops below this threshold.",
     )
     parser.add_argument(
-        "--output", "-o", default="deconv_result.tif", help="Output file path."
+        "--output",
+        "-o",
+        type=Path,
+        default=Path("deconv_result.tif"),
+        help="Output file path.",
     )
     parser.add_argument("--enable-cuda", action="store_true", help="Use CUDA backend.")
     parser.add_argument(
@@ -136,12 +142,15 @@ def main():
 
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
 
-    if not Path(args.image).is_file():
+    if not args.image.is_file():
         sys.exit(f"Image not found: {args.image}")
 
-    image = _load_image(args.image)
+    image = _load_image(str(args.image))
     psf = _get_psf(
-        image, args.psf, list(args.fwhm), list(args.fov) if args.fov else None
+        image,
+        str(args.psf) if args.psf else None,
+        list(args.fwhm),
+        list(args.fov) if args.fov else None,
     )
 
     psf_arr, adj_psf_arr = prepare_psf(psf, image.spacing)
@@ -168,7 +177,7 @@ def main():
     )
 
     print(
-        f"Deconvolving {Path(args.image).name} "
+        f"Deconvolving {args.image.name} "
         f"({image.shape}) with {args.iterations} iterations "
         f"({'CUDA' if args.enable_cuda else 'CPU'})"
     )

--- a/miplib/bin/fuse.py
+++ b/miplib/bin/fuse.py
@@ -9,7 +9,6 @@ of the BSD license.  See the LICENSE file for details.
 This is the main program file for the miplib fusion calculation.
 """
 
-import os
 import sys
 import tempfile
 import time
@@ -95,11 +94,11 @@ def _create_view_data(data, views, options):
 
 def main():
     options = arguments.get_fusion_script_options(sys.argv[1:])
-    full_path = os.path.join(options.working_directory, options.data_file)
+    full_path = Path(options.working_directory) / options.data_file
 
-    if not os.path.isfile(full_path):
+    if not full_path.is_file():
         raise AttributeError(f"No such file: {full_path}")
-    elif not full_path.endswith(".hdf5"):
+    elif full_path.suffix != ".hdf5":
         raise AttributeError("Not a HDF5 file")
 
     data = image_data.ImageData(full_path)

--- a/miplib/bin/fuse.py
+++ b/miplib/bin/fuse.py
@@ -94,7 +94,7 @@ def _create_view_data(data, views, options):
 
 def main():
     options = arguments.get_fusion_script_options(sys.argv[1:])
-    full_path = Path(options.working_directory) / options.data_file
+    full_path = options.working_directory / options.data_file
 
     if not full_path.is_file():
         raise AttributeError(f"No such file: {full_path}")

--- a/miplib/bin/import_data.py
+++ b/miplib/bin/import_data.py
@@ -54,8 +54,8 @@ psf_scale_<scale>_index_<index>_channel_<channel>_angle_<angle>.<suffix>
 
 """
 
-import os
 import sys
+from pathlib import Path
 
 import numpy
 
@@ -70,23 +70,23 @@ from ..ui.cli import miplib_entry_point_options
 
 def main():
     options = miplib_entry_point_options.get_import_script_options(sys.argv[1:])
-    directory = options.data_dir_path
+    directory = Path(options.data_dir_path)
 
     # Create a new HDF5 file. If a file exists, new data will be appended.
     file_name = input("Give a name for the HDF5 file: ")
     file_name += ".hdf5"
-    data_path = os.path.join(directory, file_name)
+    data_path = directory / file_name
     data = image_data.ImageData(data_path)
 
     # Add image files that have been named according to the correct format
-    for image_name in os.listdir(directory):
-        full_path = os.path.join(directory, image_name)
-
-        if full_path.endswith((".tiff", ".tif", ".mhd", ".mha")):
-            images = read.get_image(full_path)
-            spacing = images.spacing
-        else:
+    for full_path in directory.iterdir():
+        if not full_path.is_file():
             continue
+        image_name = full_path.name
+        if full_path.suffix not in (".tiff", ".tif", ".mhd", ".mha"):
+            continue
+        images = read.get_image(str(full_path))
+        spacing = images.spacing
 
         if options.normalize_inputs:
             images = (images * (255.0 / images.max())).astype(numpy.uint8)
@@ -121,9 +121,8 @@ def main():
             data.create_rescaled_images(ImageType.ORIGINAL, scale)
 
     # Add transforms for registered images.
-    for transform_name in os.listdir(directory):
-        if not transform_name.endswith(".txt"):
-            continue
+    for full_path in directory.glob("*.txt"):
+        transform_name = full_path.name
 
         if (
             not all(x in transform_name for x in params_c)
@@ -137,8 +136,6 @@ def main():
         channel = transform_name.split("channel_")[-1].split("_angle")[0]
         angle = transform_name.split("angle_")[-1].split(".")[0]
 
-        full_path = os.path.join(directory, transform_name)
-
         # First calculate registered image if not in the data structure
         if not data.check_if_exists(ImageType.REGISTERED, index, channel, scale):
             print("Resampling registered image for image nr. ", index)
@@ -147,7 +144,7 @@ def main():
             reference = data.get_itk_image(key_ref)
             moving = data.get_itk_image(key_moving)
 
-            transform = read.__itk_transform(full_path, return_itk=True)
+            transform = read.__itk_transform(str(full_path), return_itk=True)
 
             registered = itkutils.resample_image(moving, transform, reference=reference)
             registered = itkutils.convert_from_itk_image(registered)
@@ -156,7 +153,7 @@ def main():
             data.add_registered_image(registered, scale, index, channel, angle, spacing)
 
         # The add it's transform
-        transform_type, params, fixed_params = read.__itk_transform(full_path)
+        transform_type, params, fixed_params = read.__itk_transform(str(full_path))
         data.add_transform(scale, index, channel, params, fixed_params, transform_type)
 
     # Calculate missing PSFs

--- a/miplib/bin/import_data.py
+++ b/miplib/bin/import_data.py
@@ -55,7 +55,6 @@ psf_scale_<scale>_index_<index>_channel_<channel>_angle_<angle>.<suffix>
 """
 
 import sys
-from pathlib import Path
 
 import numpy
 
@@ -70,7 +69,7 @@ from ..ui.cli import miplib_entry_point_options
 
 def main():
     options = miplib_entry_point_options.get_import_script_options(sys.argv[1:])
-    directory = Path(options.data_dir_path)
+    directory = options.data_dir_path
 
     # Create a new HDF5 file. If a file exists, new data will be appended.
     file_name = input("Give a name for the HDF5 file: ")

--- a/miplib/bin/ism.py
+++ b/miplib/bin/ism.py
@@ -44,7 +44,7 @@ def _get_psf(image: Image, args: argparse.Namespace) -> Image:
     if args.psf:
         import SimpleITK as sitk
 
-        sitk_psf = sitk.ReadImage(args.psf)
+        sitk_psf = sitk.ReadImage(str(args.psf))
         data = sitk.GetArrayFromImage(sitk_psf)
         return Image(data, spacing=image.spacing)
 
@@ -98,7 +98,9 @@ def _build_parser() -> argparse.ArgumentParser:
             "  miplib-ism ./data/ --ism-mode rl --fwhm 2.0 --max-iterations 50\n"
         ),
     )
-    parser.add_argument("directory", help="Directory containing .mat or .czi files")
+    parser.add_argument(
+        "directory", type=Path, help="Directory containing .mat or .czi files"
+    )
     parser.add_argument(
         "--ism-mode",
         choices=["reassign", "wiener", "rl", "all"],
@@ -120,7 +122,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     # PSF options
     psf_group = parser.add_argument_group("PSF generation")
-    psf_group.add_argument("--psf", help="Path to a PSF image file")
+    psf_group.add_argument("--psf", type=Path, help="Path to a PSF image file")
     psf_group.add_argument(
         "--fwhm",
         type=float,
@@ -155,7 +157,7 @@ def main():
 
     logging.basicConfig(level=logging.INFO if args.verbose else logging.WARNING)
 
-    root = Path(args.directory)
+    root = args.directory
     if not root.is_dir():
         sys.exit(f"Not a directory: {args.directory}")
 

--- a/miplib/bin/ism.py
+++ b/miplib/bin/ism.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 
 import argparse
 import logging
-import os
 import sys
 import time
+from pathlib import Path
 
 from miplib.data.containers.image import Image
 from miplib.data.io import array_detector_data as detio
@@ -155,11 +155,11 @@ def main():
 
     logging.basicConfig(level=logging.INFO if args.verbose else logging.WARNING)
 
-    root = args.directory
-    if not os.path.isdir(root):
-        sys.exit(f"Not a directory: {root}")
+    root = Path(args.directory)
+    if not root.is_dir():
+        sys.exit(f"Not a directory: {args.directory}")
 
-    files = sorted(f for f in os.listdir(root) if f.endswith((".mat", ".czi")))
+    files = sorted(f for f in root.iterdir() if f.suffix in (".mat", ".czi"))
     if not files:
         sys.exit(f"No .mat or .czi files found in {root}")
 
@@ -169,18 +169,17 @@ def main():
     }
     method = method_map[args.method]
 
-    for filename in files:
-        full_path = os.path.join(root, filename)
-        prefix, data = _get_data(full_path)
-        prefix = os.path.join(root, os.path.basename(prefix))
+    for full_path in files:
+        prefix, data = _get_data(str(full_path))
+        prefix = root / Path(prefix).name
 
         # Default fixed_idx based on detector type
         fixed_idx = args.fixed_idx
         if fixed_idx is None:
-            fixed_idx = 0 if full_path.endswith(".czi") else 12
+            fixed_idx = 0 if str(full_path).endswith(".czi") else 12
 
         print(
-            f"\n{filename}: {data.ndetectors} detectors, "
+            f"\n{full_path.name}: {data.ndetectors} detectors, "
             f"{data.ngates} gates, shape={data[0, 0].shape}, "
             f"spacing={data[0, 0].spacing}"
         )

--- a/miplib/bin/power.py
+++ b/miplib/bin/power.py
@@ -12,8 +12,8 @@ file, each column denoting a single image.
 """
 
 import datetime
-import os
 import sys
+from pathlib import Path
 
 import numpy
 import pandas
@@ -26,31 +26,29 @@ from miplib.ui.cli import miplib_entry_point_options
 
 def main():
     options = miplib_entry_point_options.get_power_script_options(sys.argv[1:])
-    path = options.working_directory
+    path = Path(options.working_directory)
 
-    assert os.path.isdir(path)
+    assert path.is_dir()
 
     # Create output directory
     output_dir = datetime.datetime.now().strftime("%Y-%m-%d") + "_PyIQ_output"
-    output_dir = os.path.join(options.working_directory, output_dir)
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
+    output_dir = path / output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
 
     # Create output file
     date_now = datetime.datetime.now().strftime("%H-%M-%S")
     file_name = date_now + "_PyIQ_power_spectra" + ".csv"
-    file_path = os.path.join(output_dir, file_name)
+    file_path = output_dir / file_name
 
     csv_data = pandas.DataFrame()
 
     # Scan through images
-    for image_in in os.listdir(path):
-        if not image_in.endswith((".jpg", ".tif", ".tiff", ".png")):
+    for image_in in path.iterdir():
+        if image_in.suffix not in (".jpg", ".tif", ".tiff", ".png"):
             continue
-        path_in = os.path.join(path, image_in)
 
         # Get image
-        image = read.get_image(path_in, channel=options.rgb_channel)
+        image = read.get_image(str(image_in), channel=options.rgb_channel)
         image = improc.crop_to_rectangle(image)
 
         for dim in image.shape:
@@ -64,7 +62,7 @@ def main():
 
         power_spectrum = task.get_power_spectrum()
 
-        csv_data[image_in] = power_spectrum[1]
+        csv_data[image_in.name] = power_spectrum[1]
 
     csv_data.insert(0, "Power", numpy.linspace(0, 1, num=len(csv_data)))
     csv_data.to_csv(file_path, index=False)

--- a/miplib/bin/power.py
+++ b/miplib/bin/power.py
@@ -13,7 +13,6 @@ file, each column denoting a single image.
 
 import datetime
 import sys
-from pathlib import Path
 
 import numpy
 import pandas
@@ -26,7 +25,7 @@ from miplib.ui.cli import miplib_entry_point_options
 
 def main():
     options = miplib_entry_point_options.get_power_script_options(sys.argv[1:])
-    path = Path(options.working_directory)
+    path = options.working_directory
 
     assert path.is_dir()
 

--- a/miplib/bin/pyimq.py
+++ b/miplib/bin/pyimq.py
@@ -63,8 +63,8 @@ of packages in scientific articles by citing the corresponding papers:
 
 import csv
 import datetime
-import os
 import sys
+from pathlib import Path
 
 import pandas
 
@@ -79,7 +79,7 @@ def main():
     The Main program of the PyImageQualityRanking software.
     """
     options = miplib_entry_point_options.get_quality_script_options(sys.argv[1:])
-    path = options.working_directory
+    path = Path(options.working_directory)
     file_path = None
     csv_data = None
 
@@ -92,9 +92,9 @@ def main():
         assert options.file is not None, (
             "You have to specify a file with a --file option"
         )
-        path = os.path.join(path, options.file)
-        assert os.path.isfile(path)
-        image = read.get_image(path, channel=options.rgb_channel)
+        full_path = path / options.file
+        assert full_path.is_file()
+        image = read.get_image(str(full_path), channel=options.rgb_channel)
 
         print(f"The shape is {str(image.shape)}")
 
@@ -119,17 +119,16 @@ def main():
         # In directory mode every image in a given directory is analyzed in a
         # single run. The analysis results are saved into a csv file.
 
-        assert os.path.isdir(path), path
+        assert path.is_dir(), str(path)
 
         # Create output directory
         output_dir = datetime.datetime.now().strftime("%Y-%m-%d") + "_PyIQ_output"
-        output_dir = os.path.join(options.working_directory, output_dir)
-        if not os.path.exists(output_dir):
-            os.makedirs(output_dir)
+        output_dir = path / output_dir
+        output_dir.mkdir(parents=True, exist_ok=True)
         # Create output file
         date_now = datetime.datetime.now().strftime("%H-%M-%S")
         file_name = date_now + "_PyIQ_out" + ".csv"
-        file_path = os.path.join(output_dir, file_name)
+        file_path = output_dir / file_name
         output_file = open(file_path, "w")
         output_writer = csv.writer(
             output_file, quoting=csv.QUOTE_NONNUMERIC, delimiter=","
@@ -151,17 +150,20 @@ def main():
             )
         )
 
-        for image_name in os.listdir(path):
-            if options.file_filter is None or options.file_filter in image_name:
-                real_path = os.path.join(path, image_name)
-                # Only process images
-                if not os.path.isfile(real_path) or not real_path.endswith(
-                    (".jpg", ".tif", ".tiff", ".png")
-                ):
-                    continue
+        for image_entry in path.iterdir():
+            if not image_entry.is_file():
+                continue
+            image_name = image_entry.name
+            if (
+                options.file_filter is not None
+                and options.file_filter not in image_name
+            ):
+                continue
+            if image_entry.suffix not in (".jpg", ".tif", ".tiff", ".png"):
+                continue
                 # ImageJ files have particular TIFF tags that can be processed correctly
                 # with the options.imagej switch
-                image = read.get_image(real_path, channel=options.rgb_channel)
+                image = read.get_image(str(image_entry), channel=options.rgb_channel)
 
                 # Only grayscale images are processed. If the input is an RGB image,
                 # a channel can be chosen for processing.
@@ -196,7 +198,7 @@ def main():
                 results.insert(0, moments)
                 results.insert(0, brenner)
                 results.insert(0, entropy)
-                results.insert(0, os.path.join(path, image_name))
+                results.insert(0, str(image_entry))
                 output_writer.writerow(results)
 
                 print(f"Done analyzing {image_name}")
@@ -213,12 +215,11 @@ def main():
             assert options.file is not None, (
                 "You have to specify a data filewith the --file option"
             )
-            path = os.path.join(options.working_directory, options.file)
-            print(path)
-            file_path = path
-            assert os.path.isfile(path), f"Not a valid file {path}"
-            assert path.endswith(".csv"), "Unknown suffix {}".format(
-                path.split(".")[-1]
+            file_path = path / options.file
+            print(file_path)
+            assert file_path.is_file(), f"Not a valid file {file_path}"
+            assert str(file_path).endswith(".csv"), "Unknown suffix {}".format(
+                str(file_path).split(".")[-1]
             )
 
         csv_data = pandas.read_csv(file_path)
@@ -237,12 +238,11 @@ def main():
 
         # Create output directory
         output_dir = datetime.datetime.now().strftime("%Y-%m-%d") + "_PyIQ_output"
-        output_dir = os.path.join(options.working_directory, output_dir)
-        if not os.path.exists(output_dir):
-            os.makedirs(output_dir)
+        output_dir = path / output_dir
+        output_dir.mkdir(parents=True, exist_ok=True)
         date_now = datetime.datetime.now().strftime("%H-%M-%S")
         file_name = date_now + "_PyIQ_analyze_out" + ".csv"
-        file_path = os.path.join(output_dir, file_name)
+        file_path = output_dir / file_name
 
         csv_data.to_csv(file_path)
         print(f"The results were saved to {file_path}")
@@ -253,10 +253,10 @@ def main():
         # a subset of highest and lowest ranked images (the amount of images to show is
         # controlled by the options.npics parameter
         if csv_data is None:
-            file_path = os.path.join(options.working_directory, options.file)
-            assert os.path.isfile(file_path), f"Not a valid file {path}"
-            assert path.endswith(".csv"), "Unknown suffix {}".format(
-                path.split(".")[-1]
+            file_path = path / options.file
+            assert file_path.is_file(), f"Not a valid file {file_path}"
+            assert str(file_path).endswith(".csv"), "Unknown suffix {}".format(
+                str(file_path).split(".")[-1]
             )
             csv_data = pandas.read_csv(file_path)
         if options.result == "average":

--- a/miplib/bin/pyimq.py
+++ b/miplib/bin/pyimq.py
@@ -64,7 +64,6 @@ of packages in scientific articles by citing the corresponding papers:
 import csv
 import datetime
 import sys
-from pathlib import Path
 
 import pandas
 
@@ -79,7 +78,7 @@ def main():
     The Main program of the PyImageQualityRanking software.
     """
     options = miplib_entry_point_options.get_quality_script_options(sys.argv[1:])
-    path = Path(options.working_directory)
+    path = options.working_directory
     file_path = None
     csv_data = None
 

--- a/miplib/bin/register.py
+++ b/miplib/bin/register.py
@@ -46,7 +46,7 @@ def _resolve_source(args: argparse.Namespace) -> RegistrationDataSource:
     output_dir: str = getattr(args, "output_dir", ".")
 
     if len(args.images) == 1:
-        p = Path(args.images[0])
+        p = args.images[0]
 
         if p.suffix == ".hdf5":
             from miplib.data.containers.image_data import ImageData, ImageType
@@ -131,7 +131,10 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
-        "images", nargs="+", help="Input images, a directory, or an HDF5 file"
+        "images",
+        nargs="+",
+        type=Path,
+        help="Input images, a directory, or an HDF5 file",
     )
     parser.add_argument(
         "--method",
@@ -144,11 +147,16 @@ def _build_parser() -> argparse.ArgumentParser:
         "--fixed-idx", type=int, default=0, help="Reference image index (default: 0)"
     )
     parser.add_argument(
-        "--output", "-o", nargs="*", help="Output paths for registered images"
+        "--output",
+        "-o",
+        nargs="*",
+        type=Path,
+        help="Output paths for registered images",
     )
     parser.add_argument(
         "--output-dir",
-        default=".",
+        default=Path("."),
+        type=Path,
         help="Output directory (default: current directory)",
     )
 

--- a/miplib/bin/resolution.py
+++ b/miplib/bin/resolution.py
@@ -4,8 +4,8 @@ I have a nicer version in a notebook -- will be updated.
 """
 
 import datetime
-import os
 import sys
+from pathlib import Path
 
 import numpy as np
 import pandas
@@ -19,20 +19,19 @@ from miplib.data.io import read as imread
 def main():
     # Get input arguments
     args = options.get_frc_script_options(sys.argv[1:])
-    path = args.directory
+    path = Path(args.directory)
 
     # Create output directory
     output_dir = args.directory
     date_now = datetime.datetime.now().strftime("%H-%M-%S")
 
     filename = f"{date_now}_miplib_{args.frc_mode}_frc_results.csv"
-    filename = os.path.join(output_dir, filename)
+    filename = Path(output_dir) / filename
 
     # Get image file names, sort in alphabetic order and complete.
-    files_list = [
-        i for i in os.listdir(path) if i.endswith((".jpg", ".tif", ".tiff", ".png"))
-    ]
-    files_list.sort()
+    files_list = sorted(
+        str(p) for p in path.iterdir() if p.suffix in (".jpg", ".tif", ".tiff", ".png")
+    )
     print(f"Number of images to analyze: {len(files_list)}")
 
     # df_main = pandas.DataFrame(0, index=np.arange(len(files_list)), columns=["Image", "Depth", "Kind", "Resolution"])
@@ -48,8 +47,8 @@ def main():
 
         for idx, im1, im2 in enumerate(pairwise(files_list)):
             # Read images
-            image1 = imread.get_image(os.path.join(path, im1))
-            image2 = imread.get_image(os.path.join(path, im2))
+            image1 = imread.get_image(im1)
+            image2 = imread.get_image(im2)
 
             result = frc.calculate_two_image_frc(image1, image2, args)
             title = strutils.common_start(im1, im2)
@@ -59,7 +58,7 @@ def main():
 
     elif args.frc_mode == "one-image":
         for idx, im in enumerate(files_list):
-            image = imread.get_image(os.path.join(path, im))
+            image = imread.get_image(im)
 
             print(f"Analyzing image {im}")
 

--- a/miplib/bin/resolution.py
+++ b/miplib/bin/resolution.py
@@ -5,7 +5,6 @@ I have a nicer version in a notebook -- will be updated.
 
 import datetime
 import sys
-from pathlib import Path
 
 import numpy as np
 import pandas
@@ -19,14 +18,14 @@ from miplib.data.io import read as imread
 def main():
     # Get input arguments
     args = options.get_frc_script_options(sys.argv[1:])
-    path = Path(args.directory)
+    path = args.directory
 
     # Create output directory
     output_dir = args.directory
     date_now = datetime.datetime.now().strftime("%H-%M-%S")
 
     filename = f"{date_now}_miplib_{args.frc_mode}_frc_results.csv"
-    filename = Path(output_dir) / filename
+    filename = output_dir / filename
 
     # Get image file names, sort in alphabetic order and complete.
     files_list = sorted(

--- a/miplib/bin/subjective.py
+++ b/miplib/bin/subjective.py
@@ -14,8 +14,8 @@ several ranking results in a single csv file. At every run the data
 is shuffled in order to not repeat the same image sequence twice.
 """
 
-import os
 import sys
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 import pandas
@@ -25,16 +25,16 @@ import miplib.ui.cli.miplib_entry_point_options as script_options
 
 def main():
     options = script_options.get_subjective_ranking_options(sys.argv[1:])
-    path = options.working_directory
+    path = Path(options.working_directory)
     index = 0
-    assert os.path.isdir(path), path
+    assert path.is_dir(), str(path)
 
     # Create or open a csv file
     output_dir = path
     file_name = "subjective_ranking_scores.csv"
-    file_path = os.path.join(output_dir, file_name)
+    file_path = output_dir / file_name
 
-    if os.path.exists(file_path):
+    if file_path.exists():
         csv_data = pandas.read_csv(file_path)
         # Append a new result column
         for column in csv_data:
@@ -44,13 +44,15 @@ def main():
         csv_data = pandas.DataFrame()
         file_names = []
         # Get valid file names
-        for image_name in os.listdir(path):
-            real_path = os.path.join(path, image_name)
-            if not os.path.isfile(real_path) or not real_path.endswith(
-                (".jpg", ".tif", ".tiff", ".png")
+        for image_entry in path.iterdir():
+            if not image_entry.is_file() or image_entry.suffix not in (
+                ".jpg",
+                ".tif",
+                ".tiff",
+                ".png",
             ):
                 continue
-            file_names.append(image_name)
+            file_names.append(image_entry.name)
         csv_data["Filename"] = file_names
 
     result_name = "Result_" + str(index)
@@ -68,7 +70,7 @@ def main():
     )
 
     for image_name in csv_data["Filename"]:
-        real_path = os.path.join(path, image_name)
+        real_path = path / image_name
         image = plt.imread(real_path)
 
         plt.imshow(image, cmap="hot", vmax=image.max(), vmin=image.min())

--- a/miplib/bin/subjective.py
+++ b/miplib/bin/subjective.py
@@ -15,7 +15,6 @@ is shuffled in order to not repeat the same image sequence twice.
 """
 
 import sys
-from pathlib import Path
 
 import matplotlib.pyplot as plt
 import pandas
@@ -25,7 +24,7 @@ import miplib.ui.cli.miplib_entry_point_options as script_options
 
 def main():
     options = script_options.get_subjective_ranking_options(sys.argv[1:])
-    path = Path(options.working_directory)
+    path = options.working_directory
     index = 0
     assert path.is_dir(), str(path)
 

--- a/miplib/data/containers/image_data_store.py
+++ b/miplib/data/containers/image_data_store.py
@@ -1,8 +1,8 @@
 import logging
-import os
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import StrEnum
+from pathlib import Path
 from typing import Any, Protocol
 
 import h5py
@@ -155,15 +155,15 @@ class ImageDataStore(Protocol):
 class HDF5ImageStore:
     """HDF5-backed implementation of ImageDataStore."""
 
-    def __init__(self, path: str) -> None:
+    def __init__(self, path: str | Path) -> None:
         """Open an HDF5 file at *path*, creating it if necessary.
 
         The parent directory is created automatically.
         """
-        directory = os.path.dirname(path) or "."
-        os.makedirs(directory, exist_ok=True)
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
 
-        if os.path.exists(path):
+        if path.exists():
             self._file = h5py.File(path, mode="r+")
             self._series_count = int(self._file.attrs["series_count"])
             self._channel_count = int(self._file.attrs["channel_count"])

--- a/miplib/data/io/array_detector_data.py
+++ b/miplib/data/io/array_detector_data.py
@@ -1,5 +1,5 @@
 import itertools
-import os
+from pathlib import Path
 
 import numpy as np
 import pims
@@ -103,14 +103,14 @@ def read_tiff_sequence(path, detectors=25, channels=1):
     :return: the ArrayDetectorData object that cotnains the imported data
     """
 
-    files = sorted(filter(lambda x: x.endswith(".tif"), os.listdir(path)))
+    files = sorted(Path(path).glob("*.tif"))
     if len(files) != detectors * channels:
         raise RuntimeError("The number of images does not match the data definition.")
 
     data = ArrayDetectorData(detectors, channels)
     steps = itertools.product(range(channels), range(detectors))
     for idx, (channel, detector) in enumerate(steps):
-        image = imread.get_image(os.path.join(path, files[idx]))
+        image = imread.get_image(files[idx])
         data[detector, channel] = image
 
     return data

--- a/miplib/data/io/fourier_correlation_data_reader.py
+++ b/miplib/data/io/fourier_correlation_data_reader.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import h5py
 
@@ -12,11 +12,12 @@ from miplib.data.containers.image import Image
 class FourierCorrelationDataReader:
     """Read Fourier Correlation Data from an HDF5 file."""
 
-    def __init__(self, file_path: str) -> None:
-        if not os.path.isfile(file_path) or not file_path.endswith(".hdf5"):
-            raise ValueError(f"Not a valid filename: {file_path}")
+    def __init__(self, file_path: str | Path) -> None:
+        p = Path(file_path)
+        if not p.is_file() or p.suffix != ".hdf5":
+            raise ValueError(f"Not a valid filename: {p}")
 
-        self.data = h5py.File(file_path, mode="r")
+        self.data = h5py.File(p, mode="r")
 
     def __del__(self) -> None:
         self.close()

--- a/miplib/data/io/fourier_correlation_data_writer.py
+++ b/miplib/data/io/fourier_correlation_data_writer.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import h5py
 
@@ -11,15 +11,16 @@ from miplib.data.containers.image import Image
 class FourierCorrelationDataWriter:
     """Write Fourier Correlation Data into an HDF5 file."""
 
-    def __init__(self, output_dir: str, filename: str, append: bool = False) -> None:
-        if not os.path.exists(output_dir):
-            os.makedirs(output_dir)
-
-        output_path = os.path.join(output_dir, filename)
-        if not output_path.endswith(".hdf5"):
+    def __init__(
+        self, output_dir: str | Path, filename: str, append: bool = False
+    ) -> None:
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+        output_path = output_path / filename
+        if output_path.suffix != ".hdf5":
             raise ValueError(f"Output path must end with .hdf5, got {output_path}")
 
-        mode = "r+" if (append and os.path.isfile(output_path)) else "w"
+        mode = "r+" if (append and output_path.is_file()) else "w"
         self.data = h5py.File(output_path, mode=mode)
 
     def __del__(self) -> None:

--- a/miplib/data/io/read.py
+++ b/miplib/data/io/read.py
@@ -1,5 +1,5 @@
 import logging
-import os
+from pathlib import Path
 
 import pims
 import SimpleITK as sitk
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_image(
-    filename: str,
+    filename: str | Path,
     series: int = 0,
     channel: int = 0,
     return_type: str = "image",
@@ -22,25 +22,29 @@ def get_image(
             f"Unsupported return_type {return_type!r}; use 'itk' or 'image'"
         )
 
-    if filename.endswith(".mha"):
-        return __itk_image(filename, return_type == "itk")
+    path = Path(filename)
+    if path.suffix == ".mha":
+        return __itk_image(path, return_type == "itk")
 
-    return __bioformats(filename, series, channel, return_type == "itk")
+    return __bioformats(path, series, channel, return_type == "itk")
 
 
-def __itk_image(filename: str, return_itk: bool = True) -> sitk.Image | Image:
+def __itk_image(filename: str | Path, return_itk: bool = True) -> sitk.Image | Image:
     """Read an ITK-supported image (.mha/.mhd)."""
-    if not filename.endswith((".mha", ".mhd")):
+    path = Path(filename)
+    if path.suffix not in (".mha", ".mhd"):
         raise ValueError(f"Expected .mha or .mhd extension, got {filename}")
-    image = sitk.ReadImage(filename)
+    image = sitk.ReadImage(str(path))
     if return_itk:
         return image
     return itkutils.convert_from_itk_image(image)
 
 
-def __itk_transform(path: str, return_itk: bool = False) -> tuple | sitk.Transform:
+def __itk_transform(
+    path: str | Path, return_itk: bool = False
+) -> tuple | sitk.Transform:
     """Read an ITK spatial transform from disk."""
-    if not os.path.isfile(path):
+    if not Path(path).is_file():
         raise ValueError(f"Not a valid path: {path}")
 
     transform = sitk.ReadTransform(path)
@@ -55,7 +59,7 @@ def __itk_transform(path: str, return_itk: bool = False) -> tuple | sitk.Transfo
 
 
 def __bioformats(
-    filename: str,
+    filename: str | Path,
     series: int = 0,
     channel: int = 0,
     return_itk: bool = False,
@@ -66,7 +70,7 @@ def __bioformats(
             "jpype is required for the bioformats reader. "
             "Install with: uv sync --group dev"
         )
-    reader = pims.bioformats.BioformatsReader(filename, series=series)
+    reader = pims.bioformats.BioformatsReader(str(filename), series=series)
 
     # Bioformats may interpret z-slices as channels if the file lacks OME-XML
     # metadata (common with plain tifffile-written z-stacks). Bundle 'c' as 'z'.

--- a/miplib/data/io/write.py
+++ b/miplib/data/io/write.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import SimpleITK as sitk
 import tifffile
 
@@ -5,24 +7,25 @@ import miplib.processing.itk as itkutils
 from miplib.data.containers.image import Image
 
 
-def image(path: str, image: Image) -> None:
+def image(path: str | Path, image: Image) -> None:
     """Write an Image to disk, dispatching on file extension."""
-    if path.endswith((".tiff", ".tif")):
-        __tiff(path, image, image.spacing)
-    elif path.endswith((".mha", ".mhd")):
-        __itk_image(path, image)
+    p = Path(path)
+    if p.suffix in (".tiff", ".tif"):
+        __tiff(p, image, image.spacing)
+    elif p.suffix in (".mha", ".mhd"):
+        __itk_image(p, image)
     else:
         raise ValueError(
             f"Unsupported file extension: {path}. Expected .tif, .tiff, .mha, or .mhd."
         )
 
 
-def __itk_image(path: str, image: Image) -> None:
+def __itk_image(path: str | Path, image: Image) -> None:
     """Write an Image in ITK format (.mha/.mhd)."""
-    sitk.WriteImage(itkutils.convert_to_itk_image(image), path)
+    sitk.WriteImage(itkutils.convert_to_itk_image(image), str(path))
 
 
-def __tiff(path: str, image: Image, spacing: list[float]) -> None:
+def __tiff(path: str | Path, image: Image, spacing: list[float]) -> None:
     """Write a TIFF with OME metadata (auto-converted to BigTIFF if needed)."""
     if image.ndim == 2:
         axes = "YX"

--- a/miplib/ui/cli/argparse_helpers.py
+++ b/miplib/ui/cli/argparse_helpers.py
@@ -1,6 +1,6 @@
 import argparse
-import os
 from itertools import chain
+from pathlib import Path
 
 
 def parse_range_list(rngs):
@@ -102,8 +102,8 @@ def parse_is_dir(dirname):
     Returns:
         string -- Returns the directory, if it exists.
     """
-    if not os.path.isdir(dirname):
+    p = Path(dirname)
+    if not p.is_dir():
         msg = f"{dirname} is not a directory"
         raise argparse.ArgumentTypeError(msg)
-    else:
-        return dirname
+    return dirname

--- a/miplib/ui/cli/miplib_entry_point_options.py
+++ b/miplib/ui/cli/miplib_entry_point_options.py
@@ -38,7 +38,7 @@ def get_frc_script_options(arguments):
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
-    parser.add_argument("directory")
+    parser.add_argument("directory", type=Path)
     parser.add_argument("--debug", action="store_true")
     parser.add_argument(
         "--frc-mode", choices=["two-image", "one-image"], default="one-image"
@@ -46,6 +46,7 @@ def get_frc_script_options(arguments):
     parser.add_argument(
         "--outdir",
         dest="pathout",
+        type=Path,
         help="Select output folder where to save the log file" + " and the plots",
     )
     parser = get_common_options_group(parser)
@@ -61,8 +62,8 @@ def get_deconvolve_script_options(arguments):
     parser = argparse.ArgumentParser(
         description="Command line arguments for theimage Deconvolution script"
     )
-    parser.add_argument("image")
-    parser.add_argument("psf")
+    parser.add_argument("image", type=Path)
+    parser.add_argument("psf", type=Path)
     parser = get_common_options_group(parser)
     parser = get_deconvolution_options_group(parser)
     parser = get_psf_estimation_options_group(parser)
@@ -90,7 +91,7 @@ def get_ism_script_options(arguments):
     parser = argparse.ArgumentParser(
         description="Command line arguments for theISM image reconstruction script"
     )
-    parser.add_argument("directory", type=helpers.parse_is_dir)
+    parser.add_argument("directory", type=Path)
     parser.add_argument(
         "ism_mode",
         choices=["adaptive", "static", "wiener", "rl", "all"],
@@ -160,7 +161,9 @@ def get_register_script_options(arguments):
         description="Command line arguments for the miplib image registration script"
     )
     parser.add_argument(
-        "data_file", help="Give a path to a HDF5 file that contains the images"
+        "data_file",
+        type=Path,
+        help="Give a path to a HDF5 file that contains the images",
     )
 
     parser = get_common_options_group(parser)
@@ -199,7 +202,9 @@ def get_fusion_script_options(arguments):
         ),
     )
     parser.add_argument(
-        "data_file", help="Give a path to a HDF5 file that contains the images"
+        "data_file",
+        type=Path,
+        help="Give a path to a HDF5 file that contains the images",
     )
     parser = get_common_options_group(parser)
     parser = get_fusion_options_group(parser)
@@ -226,6 +231,7 @@ def get_tem_correlation_options(parser):
         "--em",
         dest="em_image_path",
         metavar="PATH",
+        type=Path,
         default=None,
         help="Specify PATH to Electro microscope Image",
     )
@@ -235,6 +241,7 @@ def get_tem_correlation_options(parser):
         "--st",
         dest="sted_image_path",
         metavar="PATH",
+        type=Path,
         default=None,
         help="Specify PATH to STED Image",
     )
@@ -245,6 +252,7 @@ def get_tem_correlation_options(parser):
         "-t",
         dest="transform_path",
         metavar="PATH",
+        type=Path,
         help="Specify PATH to transform file",
     )
     group.add_argument(
@@ -334,7 +342,7 @@ def get_quality_script_options(arguments):
     )
 
     parser.add_argument(
-        "--file", help="Defines a path to the image files", default=None
+        "--file", type=Path, help="Defines a path to the image files", default=None
     )
     parser.add_argument("--debug", action="store_true")
     parser.add_argument(
@@ -363,8 +371,9 @@ def get_quality_script_options(arguments):
     parser.add_argument(
         "--working-directory",
         dest="working_directory",
+        type=Path,
         help="Defines the location of the working directory",
-        default="/home/sami/Pictures/Quality",
+        default=Path("/home/sami/Pictures/Quality"),
     )
     parser.add_argument(
         "--mode",
@@ -418,8 +427,9 @@ def get_power_script_options(arguments):
     parser.add_argument(
         "--working-directory",
         dest="working_directory",
+        type=Path,
         help="Defines the location of the working directory",
-        default="/home/sami/Pictures/Quality",
+        default=Path("/home/sami/Pictures/Quality"),
     )
     parser.add_argument("--image-size", dest="image_size", type=int, default=512)
     parser = filters.get_common_options(parser)
@@ -439,8 +449,9 @@ def get_subjective_ranking_options(arguments):
     parser.add_argument(
         "--working-directory",
         dest="working_directory",
+        type=Path,
         help="Defines the location of the working directory",
-        default="/home/sami/Pictures/Quality",
+        default=Path("/home/sami/Pictures/Quality"),
     )
 
     return parser.parse_args(arguments)
@@ -467,7 +478,8 @@ def get_common_options_group(parser):
     group.add_argument(
         "--dir",
         dest="working_directory",
-        default="/home/sami/Data",
+        type=Path,
+        default=Path("/home/sami/Data"),
         help="Path to image files",
     )
     group.add_argument(
@@ -521,6 +533,7 @@ def get_common_options_group(parser):
 
     group.add_argument(
         "--temp-dir",
+        type=Path,
         help="Specify a custom directory for Temp data. By default it will"
         "be saved into an automatically generated directory in the "
         "system's temp file directory (/temp on *nix)",

--- a/miplib/ui/cli/miplib_entry_point_options.py
+++ b/miplib/ui/cli/miplib_entry_point_options.py
@@ -7,6 +7,7 @@ for the various *miplib* entry points, that can be found in the
 """
 
 import argparse
+from pathlib import Path
 
 import miplib.analysis.image_quality.filters as filters
 import miplib.ui.cli.argparse_helpers as helpers
@@ -127,7 +128,7 @@ def get_import_script_options(arguments):
     parser = argparse.ArgumentParser(
         description="Command line arguments for themiplib data import script."
     )
-    parser.add_argument("data_dir_path")
+    parser.add_argument("data_dir_path", type=Path)
     parser.add_argument("--scales", type=helpers.parse_int_tuple, action="store")
     parser.add_argument("--calculate-psfs", dest="calculate_psfs", action="store_true")
 

--- a/miplib/ui/plots/frc.py
+++ b/miplib/ui/plots/frc.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -209,8 +209,9 @@ class FourierDataPlotter:
             self._rows = int(len(self.data) / self._columns + 1)
 
         if path is not None:
-            assert os.path.isdir(path)
-            self.path = path
+            p = Path(path)
+            assert p.is_dir()
+            self.path = p
 
     def plot_all(self, save_fig=False, custom_titles=None, show=True):
         """
@@ -252,7 +253,7 @@ class FourierDataPlotter:
             self.__make_frc_subplot(plot, dataset, title)
 
         if save_fig:
-            file_name = os.path.join(self.path, "all_frc_curves.eps")
+            file_name = self.path / "all_frc_curves.eps"
             plt.savefig(file_name, dpi=1200)
 
         if show:
@@ -287,7 +288,7 @@ class FourierDataPlotter:
             self.__make_printable_frc_subplot(
                 plot, dataset, title=(title if header else None)
             )
-            file_name = os.path.join(self.path, f"{title}.eps")
+            file_name = self.path / f"{title}.eps"
             plt.savefig(file_name, dpi=1200)
             plt.cla()
 
@@ -307,7 +308,7 @@ class FourierDataPlotter:
         self.__make_printable_frc_subplot(
             ax, self.data[int(angle)], title, coerce_ticks=coerce_ticks
         )
-        file_name = os.path.join(self.path, f"{filename}.eps")
+        file_name = self.path / f"{filename}.eps"
         if legend:
             fig.legend(
                 ("FRC", "curve-fit", "threshold", "resolution-point"),
@@ -408,7 +409,7 @@ class FourierDataPlotter:
         # ax.set_xlabel("XY")
         # ax.set_ylabel("Z")
 
-        file_name = os.path.join(self.path, f"{filename}.eps")
+        file_name = self.path / f"{filename}.eps"
 
         plt.savefig(
             file_name, dpi=1200, bbox_inches="tight", pad_inches=0, transparent=True

--- a/miplib/ui/plots/image.py
+++ b/miplib/ui/plots/image.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
@@ -234,7 +234,7 @@ def show_pics_from_disk(filenames, title="Image collage"):
             while j < subplots.shape[1] and k < len(filenames):
                 print(filenames[i + j])
                 subplots[i, j].imshow(plt.imread(filenames[k]), cmap="hot")
-                subplots[i, j].set_title(os.path.basename(filenames[k]))
+                subplots[i, j].set_title(Path(filenames[k]).name)
                 subplots[i, j].axis("off")
                 k += 1
                 j += 1

--- a/miplib/ui/utils.py
+++ b/miplib/ui/utils.py
@@ -3,7 +3,7 @@ Various utilities that are used to convert command line parameters into
 data types that the progrma understands.
 """
 
-import os
+from pathlib import Path
 
 file_extensions = [".tif", ".lsm", "tiff", ".raw", ".data"]
 
@@ -35,18 +35,19 @@ def get_path_dir(path, suffix):
     """Return a directory name with suffix that will be used to save data
     related to given path.
     """
-    if os.path.isfile(path):
-        path_dir = path + "." + suffix
-    elif os.path.isdir(path):
-        path_dir = os.path.join(path, suffix)
-    elif os.path.exists(path):
+    p = Path(path)
+    if p.is_file():
+        path_dir = f"{path}.{suffix}"
+    elif p.is_dir():
+        path_dir = str(p / suffix)
+    elif p.exists():
         raise ValueError(f"Not a file or directory: {path!r}")
     else:
-        base, ext = os.path.splitext(path)
+        ext = p.suffix
         if ext in file_extensions:
-            path_dir = path + "." + suffix
+            path_dir = f"{path}.{suffix}"
         else:
-            path_dir = os.path.join(path, suffix)
+            path_dir = str(p / suffix)
     return path_dir
 
 
@@ -59,11 +60,12 @@ def get_full_path(path, prefix):
     :return:        Returns the absolute path, if the file is found,
                     None otherwise
     """
-    if not os.path.isfile(path):
-        path = os.path.join(prefix, path)
-        if not os.path.isfile(path):
-            raise ValueError(f"Not a valid file {path}")
-    return path
+    p = Path(path)
+    if not p.is_file():
+        p = Path(prefix) / path
+        if not p.is_file():
+            raise ValueError(f"Not a valid file {p}")
+    return str(p)
 
 
 def get_filename_and_extension(path):

--- a/tests/data/io/test_read_write.py
+++ b/tests/data/io/test_read_write.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import numpy as np
 import numpy.testing as npt
@@ -43,7 +43,7 @@ def test_tiff_roundtrip_2d(tmp_path, shape, spacing):
     path = str(tmp_path / "test.tif")
 
     write.image(path, img)
-    assert os.path.isfile(path)
+    assert Path(path).is_file()
 
     result = read.get_image(path)
     arr = np.asarray(result)

--- a/tests/test_register_cli.py
+++ b/tests/test_register_cli.py
@@ -23,7 +23,7 @@ from miplib.processing.registration.options import Metric
 def test_parser_defaults():
     parser = _build_parser()
     args = parser.parse_args(["a.tif", "b.tif"])
-    assert args.images == ["a.tif", "b.tif"]
+    assert args.images == [Path("a.tif"), Path("b.tif")]
     assert args.method == RegistrationMethod.ITERATIVE_RIGID
     assert args.fixed_idx == 0
     assert args.learning_rate == 0.7
@@ -72,8 +72,8 @@ def test_parser_output_options():
     args = parser.parse_args(
         ["a.tif", "b.tif", "--output", "out1.tif", "out2.tif", "--output-dir", "/tmp"]
     )
-    assert args.output == ["out1.tif", "out2.tif"]
-    assert args.output_dir == "/tmp"
+    assert args.output == [Path("out1.tif"), Path("out2.tif")]
+    assert args.output_dir == Path("/tmp")
 
 
 # ---------------------------------------------------------------------------
@@ -95,7 +95,7 @@ def tmp_image_dir() -> str:
 
 def test_resolve_source_file_list(tmp_image_dir: str):
     """Multiple positional args → file mode."""
-    paths = sorted(str(p) for p in Path(tmp_image_dir).glob("*.mha"))[:2]
+    paths = sorted(Path(tmp_image_dir).glob("*.mha"))[:2]
     args = argparse.Namespace(images=paths, fixed_idx=0)
     source = _resolve_source(args)
     assert isinstance(source, ArrayRegistrationDataSource)
@@ -104,7 +104,7 @@ def test_resolve_source_file_list(tmp_image_dir: str):
 
 def test_resolve_source_directory(tmp_image_dir: str):
     """Single directory arg → dir mode (glob .mha files)."""
-    args = argparse.Namespace(images=[tmp_image_dir], fixed_idx=0)
+    args = argparse.Namespace(images=[Path(tmp_image_dir)], fixed_idx=0)
     source = _resolve_source(args)
     assert isinstance(source, ArrayRegistrationDataSource)
     assert source.n_views == 3
@@ -113,7 +113,7 @@ def test_resolve_source_directory(tmp_image_dir: str):
 def test_resolve_source_directory_no_images():
     """Empty directory → exits with error."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        args = argparse.Namespace(images=[tmpdir], fixed_idx=0)
+        args = argparse.Namespace(images=[Path(tmpdir)], fixed_idx=0)
         with pytest.raises(SystemExit):
             _resolve_source(args)
 

--- a/tests/test_register_cli.py
+++ b/tests/test_register_cli.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import argparse
-import os
 import tempfile
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -88,14 +88,14 @@ def tmp_image_dir() -> str:
         for i in range(3):
             img = np.random.default_rng(42 + i).random((32, 32)).astype(np.float32)
             sitk.WriteImage(
-                sitk.GetImageFromArray(img), os.path.join(tmpdir, f"img_{i:02d}.mha")
+                sitk.GetImageFromArray(img), str(Path(tmpdir) / f"img_{i:02d}.mha")
             )
         yield tmpdir
 
 
 def test_resolve_source_file_list(tmp_image_dir: str):
     """Multiple positional args → file mode."""
-    paths = [os.path.join(tmp_image_dir, f"img_{i:02d}.mha") for i in range(2)]
+    paths = sorted(str(p) for p in Path(tmp_image_dir).glob("*.mha"))[:2]
     args = argparse.Namespace(images=paths, fixed_idx=0)
     source = _resolve_source(args)
     assert isinstance(source, ArrayRegistrationDataSource)


### PR DESCRIPTION
Convert all `os.path.*` file system operations to `pathlib.Path` across 23 files in `miplib/` and `tests/`.

### Scope
- 79 `os.path.*` calls + 17 `os.listdir/makedirs` calls eliminated
- Libraries: `data/io/`, `data/containers/`, `analysis/`, `ui/`, `bin/`, `tests/`

### Key conversions
| Before | After |
|--------|-------|
| `os.path.join(a, b)` | `Path(a) / b` |
| `os.path.isfile(p)` | `Path(p).is_file()` |
| `os.path.isdir(p)` | `Path(p).is_dir()` |
| `os.listdir(p)` | `Path(p).iterdir()` / `.glob()` |
| `os.makedirs(p)` | `Path(p).mkdir(parents=True)` |
| `p.endswith(ext)` | `Path(p).suffix == ext` |

- `sitk.ReadImage/WriteImage` wrapped with `str()`
- All external libs (`h5py`, `pandas`, `tifffile`) accept Path natively
- ruff, mypy, 627 tests pass