### PR TITLE
refactor: 3D iterator support, sectioned accumulation, and FRC/FSC module cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ miplib/
 ## Branch & PR Discipline
 
 - **NEVER commit directly to `public`.** Always create a feature branch and open a PR.
+- **Never merge a PR.** The user handles merges.
 - Branch naming: `feature/<name>`, `refactor/<name>`, `fix/<name>`, `test/<name>`.
 
 - **Package manager**: `uv` — use `uv sync --group dev` to install all deps

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ miplib is a Python library for (optical) microscopy image restoration, reconstru
 miplib/
 ├── analysis/          # Image quality ranking, FRC/FSC resolution analysis
 │   ├── image_quality/ # Filters, quality ranking, utils
-│   └── resolution/    # FRC, FSC, analysis
+│   └── resolution/    # FRC, FSC, analysis, common (shared utilities)
 ├── bin/               # CLI entry points (wired via pyproject.toml [project.scripts])
 ├── data/              # Containers, HDF5 I/O, iterators, converters, coordinates, adapters
 │   ├── containers/    # Image, ArrayDetectorData, FourierCorrelationData, etc.
@@ -116,7 +116,7 @@ The vast majority of modules have zero test coverage. Priority candidates (small
 | ✓ done | `tests/test_register_cli.py` | Register CLI: parsing, source resolution, options (11 tests) |
 | lower | `processing/deconvolution/*` | Now has Image + blobs_3d + psf_gaussian_2d |
 | lower | `processing/fusion/*` | Now has Image + blobs_3d fixtures |
-| ✓ done | `tests/analysis/resolution/` | FRCOptions, accumulate, curve builder, analysis, first_guess |
+| ✓ done | `tests/analysis/resolution/` | FRCOptions, accumulate, curve builder, analysis, first_guess, 3D iterator, sectioned accumulation |
 | ✓ done | `tests/psf/test_psfgen.py` | FRC-based PSF generation (real ISM image) |
 | ✓ done | `tests/processing/test_deconvolver.py` | RL deconv pipeline with FRC tracker (real ISM image) |
 | ✓ done | `tests/data/core/test_dictionary.py` | FixedDictionary — __contains__, __iter__, unset-keys-return-None |
@@ -127,8 +127,6 @@ The vast majority of modules have zero test coverage. Priority candidates (small
   - Make library functions accept typed dataclasses (`RLOptions`, `RegistrationOptions`, `FusionOptions`)
   - Give non-CLI callers a clean programmatic API without constructing `argparse.Namespace`
   - Allow flexible CLI usage via `--options` JSON override (useful for automated/agent-driven workflows)
-- **3D Fourier Shell iterator factory** — `create_fourier_iterator()` currently only dispatches to 2D `FourierRingIterator`. The `FourierShellIterator` (3D) path should be added, enabling `accumulate_fourier_correlation()` to work with 3D data through the same API.
-- **Unify sectioned/directional FRC/FSC** — 2D sectioned and 3D directional correlation share ~80% of the accumulation logic but live in separate functions (`calculate_single_image_sectioned_frc` vs `calculate_one_image_sectioned_fsc`). A unified `sectioned.py` module could handle both.
 - **FFT primitives consolidation** — `miplib/processing/deconvolution/backends.py` defines `_CPUFFT`/`_CUDAFFT`/`resolve_fft` for GPU-aware `fftn`/`ifftn` dispatch. These should move into `miplib/processing/fftutils.py` so the whole library has one CPU+CUDA FFT layer. `fftutils.fft()` and `ifft()` would gain an optional `backend` kwarg. Currently `backends.py` and `wiener.py` each do their own `cupy` import guard — this should become a single import in `fftutils`.
 - **Estimate checkpoint support** — Saving/loading estimate state mid-deconvolution would allow resuming from checkpoints. Needs `EstimateIO.save(estimate, path)` / `load(path, shape, spacing)` plus metadata (iteration count, tracker state, PSF parameters).
 

--- a/miplib/analysis/image_quality/image_quality_ranking.py
+++ b/miplib/analysis/image_quality/image_quality_ranking.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from pathlib import Path
 
+from miplib.analysis.resolution.common import FRCOptions
 from miplib.analysis.resolution.fourier_ring_correlation import (
-    FRCOptions,
     calculate_single_image_frc,
 )
 from miplib.data.containers.image import Image

--- a/miplib/analysis/resolution/analysis.py
+++ b/miplib/analysis/resolution/analysis.py
@@ -184,12 +184,18 @@ class FourierCorrelationAnalysis:
 
             logger.debug("Fit starts at %s", fit_start)
 
-            root = optimize.minimize_scalar(
-                _pdiff2 if criterion == ResolutionCriterion.FIXED else _pdiff1,
-                bounds=(0, 1),
-                method="bounded",
-            ).x
-            data_set.resolution["resolution-point"] = (frc_eq(root), root)
+            try:
+                root = optimize.minimize_scalar(
+                    _pdiff2 if criterion == ResolutionCriterion.FIXED else _pdiff1,
+                    bounds=(0, 1),
+                    method="bounded",
+                ).x
+                data_set.resolution["resolution-point"] = (frc_eq(root), root)
+            except ValueError:
+                logger.debug(
+                    "Minimization failed for dataset %s (curve outside data range)", key
+                )
+                continue
             data_set.resolution["criterion"] = criterion.value
 
             angle = converters.degrees_to_radians(int(key))

--- a/miplib/analysis/resolution/common.py
+++ b/miplib/analysis/resolution/common.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+import miplib.data.iterators.fourier_ring_iterators as iterators
+import miplib.data.iterators.fourier_shell_iterators as shell_iterators
+import miplib.processing.ndarray as arrayutils
+
+from . import analysis as fsc_analysis
+
+
+def _cutoff_correction(x: float) -> float:
+    return 0.95988146 * np.exp(13.90441896 * (x - 0.97979108)) + 0.55146136
+
+
+@dataclass
+class FRCOptions:
+    d_bin: float = 1.0
+    use_hamming: bool = True
+    d_angle: float = 45.0
+    d_extract_angle: float = 5.0
+    frc_curve_fit_degree: int = 8
+    frc_curve_fit_type: fsc_analysis.FitType = fsc_analysis.FitType.SPLINE
+    resolution_threshold_criterion: fsc_analysis.ResolutionCriterion = (
+        fsc_analysis.ResolutionCriterion.FIXED
+    )
+    resolution_threshold_value: float = 1.0 / 7
+    resolution_snr_value: float = 0.25
+
+
+def namespace_to_frc_options(ns: object) -> FRCOptions:
+    fit_type_raw = getattr(ns, "frc_curve_fit_type", "spline")
+    if isinstance(fit_type_raw, fsc_analysis.FitType):
+        fit_type = fit_type_raw
+    else:
+        fit_type = fsc_analysis.FitType(fit_type_raw)
+
+    criterion_raw = getattr(ns, "resolution_threshold_criterion", "fixed")
+    if isinstance(criterion_raw, fsc_analysis.ResolutionCriterion):
+        criterion = criterion_raw
+    else:
+        criterion = fsc_analysis.ResolutionCriterion(criterion_raw)
+
+    return FRCOptions(
+        d_bin=getattr(ns, "d_bin", 1.0),
+        use_hamming=getattr(ns, "use_hamming", True),
+        d_angle=getattr(ns, "d_angle", 45.0),
+        d_extract_angle=getattr(ns, "d_extract_angle", 5.0),
+        frc_curve_fit_degree=getattr(ns, "frc_curve_fit_degree", 8),
+        frc_curve_fit_type=fit_type,
+        resolution_threshold_criterion=criterion,
+        resolution_threshold_value=getattr(ns, "resolution_threshold_value", 1.0 / 7),
+        resolution_snr_value=getattr(ns, "resolution_snr_value", 0.25),
+    )
+
+
+def create_fourier_iterator(
+    shape: tuple[int, ...], d_bin: float = 1.0
+) -> iterators.FourierRingIterator | shell_iterators.FourierShellIterator:
+    if len(shape) == 2:
+        return iterators.FourierRingIterator(shape, d_bin)
+    if len(shape) == 3:
+        return shell_iterators.FourierShellIterator(shape, d_bin)
+    raise ValueError(f"Unsupported dimensionality: {len(shape)}D")
+
+
+def accumulate_fourier_correlation(
+    fft1: np.ndarray,
+    fft2: np.ndarray,
+    iterator: iterators.FourierRingIterator | shell_iterators.FourierShellIterator,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    radii = iterator.radii
+    c1 = np.zeros(radii.shape, dtype=np.float32)
+    c2 = np.zeros(radii.shape, dtype=np.float32)
+    c3 = np.zeros(radii.shape, dtype=np.float32)
+    n_points = np.zeros(radii.shape, dtype=np.float32)
+
+    for indices, idx in iterator:
+        subset1 = fft1[indices]
+        subset2 = fft2[indices]
+        c1[idx] = np.sum(subset1 * np.conjugate(subset2)).real
+        c2[idx] = np.sum(np.abs(subset1) ** 2)
+        c3[idx] = np.sum(np.abs(subset2) ** 2)
+        n_points[idx] = len(subset1)
+
+    return c1, c2, c3, n_points
+
+
+def accumulate_sectioned_fourier_correlation(
+    fft1: np.ndarray,
+    fft2: np.ndarray,
+    iterator: shell_iterators.SectionedFourierShellIterator,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    radii, angles = iterator.steps
+    shape = (angles.shape[0], radii.shape[0])
+    c1 = np.zeros(shape, dtype=np.float32)
+    c2 = np.zeros(shape, dtype=np.float32)
+    c3 = np.zeros(shape, dtype=np.float32)
+    n_points = np.zeros(shape, dtype=np.float32)
+
+    for indices, shell_idx, rotation_idx in iterator:
+        subset1 = fft1[indices]
+        subset2 = fft2[indices]
+        c1[rotation_idx, shell_idx] = np.sum(subset1 * np.conjugate(subset2)).real
+        c2[rotation_idx, shell_idx] = np.sum(np.abs(subset1) ** 2)
+        c3[rotation_idx, shell_idx] = np.sum(np.abs(subset2) ** 2)
+        n_points[rotation_idx, shell_idx] = len(subset1)
+
+    return c1, c2, c3, n_points
+
+
+def build_correlation_curve(
+    c1: np.ndarray,
+    c2: np.ndarray,
+    c3: np.ndarray,
+    radii: np.ndarray,
+    nyquist: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    spatial_freq = radii.astype(np.float32) / nyquist
+    frc = arrayutils.safe_divide(np.abs(c1), np.sqrt(c2 * c3))
+    return spatial_freq, frc

--- a/miplib/analysis/resolution/common.py
+++ b/miplib/analysis/resolution/common.py
@@ -100,7 +100,7 @@ def accumulate_sectioned_fourier_correlation(
     c3 = np.zeros(shape, dtype=np.float32)
     n_points = np.zeros(shape, dtype=np.float32)
 
-    for indices, shell_idx, rotation_idx in iterator:
+    for indices, shell_idx, rotation_idx in iterator:  # type: ignore[misc]
         subset1 = fft1[indices]
         subset2 = fft2[indices]
         c1[rotation_idx, shell_idx] = np.sum(subset1 * np.conjugate(subset2)).real

--- a/miplib/analysis/resolution/common.py
+++ b/miplib/analysis/resolution/common.py
@@ -7,6 +7,9 @@ import numpy as np
 import miplib.data.iterators.fourier_ring_iterators as iterators
 import miplib.data.iterators.fourier_shell_iterators as shell_iterators
 import miplib.processing.ndarray as arrayutils
+from miplib.data.containers.fourier_correlation_data import (
+    FourierCorrelationData,
+)
 
 from . import analysis as fsc_analysis
 
@@ -118,6 +121,22 @@ def build_correlation_curve(
     radii: np.ndarray,
     nyquist: float,
 ) -> tuple[np.ndarray, np.ndarray]:
-    spatial_freq = radii.astype(np.float32) / nyquist
+    spatial_freq = _radii_to_spatial_freq(radii, nyquist)
     frc = arrayutils.safe_divide(np.abs(c1), np.sqrt(c2 * c3))
     return spatial_freq, frc
+
+
+def make_correlation_data(
+    correlation: np.ndarray,
+    frequency: np.ndarray,
+    points_per_bin: np.ndarray,
+) -> FourierCorrelationData:
+    data = FourierCorrelationData()
+    data.correlation["correlation"] = correlation
+    data.correlation["frequency"] = frequency
+    data.correlation["points-x-bin"] = points_per_bin
+    return data
+
+
+def _radii_to_spatial_freq(radii: np.ndarray, nyquist: float) -> np.ndarray:
+    return radii.astype(np.float32) / nyquist

--- a/miplib/analysis/resolution/fourier_ring_correlation.py
+++ b/miplib/analysis/resolution/fourier_ring_correlation.py
@@ -17,6 +17,7 @@ from .common import (
     _cutoff_correction,
     accumulate_fourier_correlation,
     build_correlation_curve,
+    make_correlation_data,
 )
 
 
@@ -164,10 +165,12 @@ def calculate_single_image_sectioned_frc(
 
 
 class FRC:
-    def __init__(self, image1, image2, iterator):
-        assert isinstance(image1, Image)
-        assert isinstance(image2, Image)
-
+    def __init__(
+        self,
+        image1: Image,
+        image2: Image,
+        iterator: iterators.FourierRingIterator,
+    ) -> None:
         if image1.shape != image2.shape or tuple(image1.spacing) != tuple(
             image2.spacing
         ):
@@ -198,9 +201,4 @@ class FRC:
             c1, c2, c3, self.iterator.radii, self.freq_nyq
         )
 
-        data_set = FourierCorrelationData()
-        data_set.correlation["correlation"] = frc
-        data_set.correlation["frequency"] = spatial_freq
-        data_set.correlation["points-x-bin"] = n_points
-
-        return data_set
+        return make_correlation_data(frc, spatial_freq, n_points)

--- a/miplib/analysis/resolution/fourier_ring_correlation.py
+++ b/miplib/analysis/resolution/fourier_ring_correlation.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 import numpy as np
 
 import miplib.data.iterators.fourier_ring_iterators as iterators
 import miplib.processing.image as imops
-import miplib.processing.ndarray as arrayutils
 from miplib.data.containers.fourier_correlation_data import (
     FourierCorrelationData,
     FourierCorrelationDataCollection,
@@ -15,128 +12,12 @@ from miplib.data.containers.image import Image
 from miplib.processing import fftutils, windowing
 
 from . import analysis as fsc_analysis
-
-
-def _cutoff_correction(x: float) -> float:
-    """Exponential cutoff correction from Koho et al. (2019).
-
-    Koho, S. et al. Fourier ring correlation simplifies image restoration
-    in fluorescence microscopy. Nat. Commun. 10, 3103 (2019).
-    """
-    return 0.95988146 * np.exp(13.90441896 * (x - 0.97979108)) + 0.55146136
-
-
-@dataclass
-class FRCOptions:
-    d_bin: float = 1.0
-    use_hamming: bool = True
-    d_angle: float = 45.0
-    d_extract_angle: float = 5.0
-    frc_curve_fit_degree: int = 8
-    frc_curve_fit_type: fsc_analysis.FitType = fsc_analysis.FitType.SPLINE
-    resolution_threshold_criterion: fsc_analysis.ResolutionCriterion = (
-        fsc_analysis.ResolutionCriterion.FIXED
-    )
-    resolution_threshold_value: float = 1.0 / 7
-    resolution_snr_value: float = 0.25
-
-
-def namespace_to_frc_options(ns: object) -> FRCOptions:
-    """Convert an argparse.Namespace or any object to FRCOptions.
-
-    Extracts only the fields that match FRCOptions field names.
-    """
-    fit_type_raw = getattr(ns, "frc_curve_fit_type", "spline")
-    if isinstance(fit_type_raw, fsc_analysis.FitType):
-        fit_type = fit_type_raw
-    else:
-        fit_type = fsc_analysis.FitType(fit_type_raw)
-
-    criterion_raw = getattr(ns, "resolution_threshold_criterion", "fixed")
-    if isinstance(criterion_raw, fsc_analysis.ResolutionCriterion):
-        criterion = criterion_raw
-    else:
-        criterion = fsc_analysis.ResolutionCriterion(criterion_raw)
-
-    return FRCOptions(
-        d_bin=getattr(ns, "d_bin", 1.0),
-        use_hamming=getattr(ns, "use_hamming", True),
-        d_angle=getattr(ns, "d_angle", 45.0),
-        d_extract_angle=getattr(ns, "d_extract_angle", 5.0),
-        frc_curve_fit_degree=getattr(ns, "frc_curve_fit_degree", 8),
-        frc_curve_fit_type=fit_type,
-        resolution_threshold_criterion=criterion,
-        resolution_threshold_value=getattr(ns, "resolution_threshold_value", 1.0 / 7),
-        resolution_snr_value=getattr(ns, "resolution_snr_value", 0.25),
-    )
-
-
-def create_fourier_iterator(
-    shape: tuple[int, ...], d_bin: float = 1.0
-) -> iterators.FourierRingIterator:
-    """Create a Fourier iterator for the given image shape.
-
-    Currently supports 2D only. 3D (FourierShellIterator) is the next step.
-    """
-    if len(shape) == 2:
-        return iterators.FourierRingIterator(shape, d_bin)
-    raise ValueError(f"Unsupported dimensionality: {len(shape)}D")
-
-
-def accumulate_fourier_correlation(
-    fft1: np.ndarray,
-    fft2: np.ndarray,
-    iterator: iterators.FourierRingIterator,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-    """Iterate over Fourier rings/shells and accumulate c1, c2, c3, n_points.
-
-    Args:
-        fft1: FFT of first image.
-        fft2: FFT of second image.
-        iterator: A Fourier ring/shell iterator yielding (indices, bin_idx) tuples.
-
-    Returns:
-        (c1, c2, c3, n_points) arrays, one per radial bin.
-    """
-    radii = iterator.radii
-    c1 = np.zeros(radii.shape, dtype=np.float32)
-    c2 = np.zeros(radii.shape, dtype=np.float32)
-    c3 = np.zeros(radii.shape, dtype=np.float32)
-    n_points = np.zeros(radii.shape, dtype=np.float32)
-
-    for indices, idx in iterator:
-        subset1 = fft1[indices]
-        subset2 = fft2[indices]
-        c1[idx] = np.sum(subset1 * np.conjugate(subset2)).real
-        c2[idx] = np.sum(np.abs(subset1) ** 2)
-        c3[idx] = np.sum(np.abs(subset2) ** 2)
-        n_points[idx] = len(subset1)
-
-    return c1, c2, c3, n_points
-
-
-def build_correlation_curve(
-    c1: np.ndarray,
-    c2: np.ndarray,
-    c3: np.ndarray,
-    radii: np.ndarray,
-    nyquist: float,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Compute the FRC curve from accumulated correlation values.
-
-    Args:
-        c1: Sum of F1 * conj(F2) per bin.
-        c2: Sum of |F1|^2 per bin.
-        c3: Sum of |F2|^2 per bin.
-        radii: Radial distances for each bin.
-        nyquist: Nyquist frequency for normalization.
-
-    Returns:
-        (spatial_freq, correlation) arrays.
-    """
-    spatial_freq = radii.astype(np.float32) / nyquist
-    frc = arrayutils.safe_divide(np.abs(c1), np.sqrt(c2 * c3))
-    return spatial_freq, frc
+from .common import (
+    FRCOptions,
+    _cutoff_correction,
+    accumulate_fourier_correlation,
+    build_correlation_curve,
+)
 
 
 def calculate_single_image_frc(
@@ -283,11 +164,6 @@ def calculate_single_image_sectioned_frc(
 
 
 class FRC:
-    """
-    A class for calcuating 2D Fourier ring correlation. Contains
-    methods to calculate the FRC as well as to plot the results.
-    """
-
     def __init__(self, image1, image2, iterator):
         assert isinstance(image1, Image)
         assert isinstance(image2, Image)
@@ -314,11 +190,6 @@ class FRC:
         self.freq_nyq = int(np.floor(image1.shape[0] / 2.0))
 
     def execute(self):
-        """
-        Calculate the FRC
-        :return: Returns the FRC results.
-
-        """
         c1, c2, c3, n_points = accumulate_fourier_correlation(
             self.fft_image1, self.fft_image2, self.iterator
         )

--- a/miplib/analysis/resolution/fourier_shell_correlation.py
+++ b/miplib/analysis/resolution/fourier_shell_correlation.py
@@ -16,7 +16,11 @@ from miplib.data.containers.image import Image
 from miplib.processing import fftutils, windowing
 
 from . import analysis as fsc_analysis
-from .fourier_ring_correlation import FRCOptions, _cutoff_correction
+from .common import (
+    FRCOptions,
+    _cutoff_correction,
+    accumulate_sectioned_fourier_correlation,
+)
 
 
 def calculate_fourier_plane_correlation(
@@ -76,8 +80,9 @@ def calculate_one_image_sectioned_fsc(
 
     image1, image2 = imops.checkerboard_split(image)
 
-    image1 = Image(windowing.apply_hamming_window(image1), image1.spacing)
-    image2 = Image(windowing.apply_hamming_window(image2), image2.spacing)
+    if options.use_hamming:
+        image1 = Image(windowing.apply_hamming_window(image1), image1.spacing)
+        image2 = Image(windowing.apply_hamming_window(image2), image2.spacing)
 
     iterator = iterators.AxialExcludeSectionedFourierShellIterator(
         image1.shape, options.d_bin, options.d_angle, options.d_extract_angle
@@ -111,8 +116,9 @@ def calculate_two_image_sectioned_fsc(
     if options is None:
         options = FRCOptions()
 
-    image1 = Image(windowing.apply_hamming_window(image1), image1.spacing)
-    image2 = Image(windowing.apply_hamming_window(image2), image2.spacing)
+    if options.use_hamming:
+        image1 = Image(windowing.apply_hamming_window(image1), image1.spacing)
+        image2 = Image(windowing.apply_hamming_window(image2), image2.spacing)
 
     iterator = iterators.AxialExcludeSectionedFourierShellIterator(
         image1.shape, options.d_bin, options.d_angle, options.d_extract_angle
@@ -165,30 +171,16 @@ class DirectionalFSC:
                  The return value is just for convenience.
         """
 
+        c1, c2, c3, points = accumulate_sectioned_fourier_correlation(
+            self.fft_image1, self.fft_image2, self.iterator
+        )
+
         data_structure = containers.FourierCorrelationDataCollection()
         radii, angles = self.iterator.steps
         freq_nyq = self.iterator.nyquist
-        shape = (angles.shape[0], radii.shape[0])
-        c1 = np.zeros(shape, dtype=np.float32)
-        c2 = np.zeros(shape, dtype=np.float32)
-        c3 = np.zeros(shape, dtype=np.float32)
-        points = np.zeros(shape, dtype=np.float32)
 
-        # Iterate through the sphere and calculate initial values
-        for ind_ring, shell_idx, rotation_idx in self.iterator:
-            subset1 = self.fft_image1[ind_ring]
-            subset2 = self.fft_image2[ind_ring]
-
-            c1[rotation_idx, shell_idx] = np.sum(subset1 * np.conjugate(subset2)).real
-            c2[rotation_idx, shell_idx] = np.sum(np.abs(subset1) ** 2)
-            c3[rotation_idx, shell_idx] = np.sum(np.abs(subset2) ** 2)
-
-            points[rotation_idx, shell_idx] = len(subset1)
-
-        # Finish up FRC calculation for every rotation angle and sav
-        # results to the data structure.
         for i in range(angles.size):
-            # Calculate FRC for every orientation
+            # Calculate FSC for every orientation
             spatial_freq = radii.astype(np.float32) / freq_nyq
             n_points = np.array(points[i])
             frc = ndarray.safe_divide(c1[i], np.sqrt(c2[i] * c3[i]))

--- a/miplib/analysis/resolution/fourier_shell_correlation.py
+++ b/miplib/analysis/resolution/fourier_shell_correlation.py
@@ -19,7 +19,9 @@ from . import analysis as fsc_analysis
 from .common import (
     FRCOptions,
     _cutoff_correction,
+    _radii_to_spatial_freq,
     accumulate_sectioned_fourier_correlation,
+    make_correlation_data,
 )
 
 
@@ -131,13 +133,15 @@ def calculate_two_image_sectioned_fsc(
 
 
 class DirectionalFSC:
-    def __init__(self, image1, image2, iterator, normalize_power=False):
-        assert isinstance(image1, Image)
-        assert isinstance(image2, Image)
-
+    def __init__(
+        self,
+        image1: Image,
+        image2: Image,
+        iterator: iterators.SectionedFourierShellIterator,
+        normalize_power: bool = False,
+    ) -> None:
         if image1.ndim != 3 or image1.shape[0] <= 1:
             raise ValueError("You should provide a stack for FSC analysis")
-
         if image1.shape != image2.shape:
             raise ValueError("Image dimensions do not match")
 
@@ -180,18 +184,10 @@ class DirectionalFSC:
         freq_nyq = self.iterator.nyquist
 
         for i in range(angles.size):
-            # Calculate FSC for every orientation
-            spatial_freq = radii.astype(np.float32) / freq_nyq
-            n_points = np.array(points[i])
-            frc = ndarray.safe_divide(c1[i], np.sqrt(c2[i] * c3[i]))
-
-            result = containers.FourierCorrelationData()
-            result.correlation["correlation"] = frc
-            result.correlation["frequency"] = spatial_freq
-            result.correlation["points-x-bin"] = n_points
-
-            # Save result to the structure and move to next
-            # angle
-            data_structure[angles[i]] = result
+            spatial_freq = _radii_to_spatial_freq(radii, freq_nyq)
+            fsc = ndarray.safe_divide(c1[i], np.sqrt(c2[i] * c3[i]))
+            data_structure[angles[i]] = make_correlation_data(
+                fsc, spatial_freq, np.array(points[i])
+            )
 
         return data_structure

--- a/miplib/bin/deconvolve.py
+++ b/miplib/bin/deconvolve.py
@@ -182,7 +182,7 @@ def main():
     )
     estimate = create_estimate(source, FirstEstimate(args.first_estimate))
 
-    from miplib.analysis.resolution.fourier_ring_correlation import FRCOptions
+    from miplib.analysis.resolution.common import FRCOptions
     from miplib.utils.dataclasses import options_from_dict
 
     frc_options = options_from_dict(

--- a/miplib/bin/resolution.py
+++ b/miplib/bin/resolution.py
@@ -8,6 +8,7 @@ import pandas
 
 import miplib.analysis.resolution.fourier_ring_correlation as frc
 import miplib.utils.string as strutils
+from miplib.analysis.resolution import common as frc_common
 from miplib.data.io import read as imread
 from miplib.utils.dataclasses import options_from_dict
 
@@ -36,7 +37,7 @@ def main():
     path = args.directory
 
     frc_options = options_from_dict(
-        frc.FRCOptions,
+        frc_common.FRCOptions,
         json.loads(args.frc_options) if args.frc_options else None,
     )
 

--- a/miplib/processing/deconvolution/tracker.py
+++ b/miplib/processing/deconvolution/tracker.py
@@ -4,8 +4,8 @@ import logging
 
 import pandas as pd
 
+from miplib.analysis.resolution.common import FRCOptions
 from miplib.analysis.resolution.fourier_ring_correlation import (
-    FRCOptions,
     calculate_single_image_frc,
 )
 from miplib.data.containers.image import Image

--- a/miplib/psf/psfgen.py
+++ b/miplib/psf/psfgen.py
@@ -3,8 +3,8 @@ import math
 
 from psf import _psf, psf  # type: ignore[attr-defined]
 
+from miplib.analysis.resolution.common import FRCOptions
 from miplib.analysis.resolution.fourier_ring_correlation import (
-    FRCOptions,
     calculate_single_image_frc,
 )
 from miplib.data.containers.image import Image

--- a/tests/analysis/resolution/test_analysis.py
+++ b/tests/analysis/resolution/test_analysis.py
@@ -53,7 +53,7 @@ def test_first_guess_at_threshold(threshold, expected_idx):
 
 
 def _make_analysis_options():
-    from miplib.analysis.resolution.fourier_ring_correlation import FRCOptions
+    from miplib.analysis.resolution.common import FRCOptions
 
     return FRCOptions(frc_curve_fit_type=FitType.POLYNOMIAL)
 

--- a/tests/analysis/resolution/test_fourier_ring_correlation.py
+++ b/tests/analysis/resolution/test_fourier_ring_correlation.py
@@ -341,8 +341,8 @@ def test_one_image_sectioned_fsc_returns_data_collection(noisy_blobs_3d):
     assert isinstance(result, FourierCorrelationDataCollection)
     assert len(result) > 0
     for _angle, dataset in result:
-        if dataset.resolution["resolution-point"] is not None:
-            assert np.isfinite(dataset.resolution["resolution"])
+        assert dataset.resolution["resolution-point"] is not None
+        assert np.isfinite(dataset.resolution["resolution"])
 
 
 def test_one_image_sectioned_fsc_disabling_hamming_still_works(noisy_blobs_3d):
@@ -353,11 +353,11 @@ def test_one_image_sectioned_fsc_disabling_hamming_still_works(noisy_blobs_3d):
     opts = FRCOptions(use_hamming=False)
     result = calculate_one_image_sectioned_fsc(noisy_blobs_3d, opts)
     for _angle, dataset in result:
-        if dataset.resolution["resolution-point"] is not None:
-            assert np.isfinite(dataset.resolution["resolution"])
+        assert dataset.resolution["resolution-point"] is not None
+        assert np.isfinite(dataset.resolution["resolution"])
 
 
-def test_two_image_sectioned_fsc_returns_data_collection(blobs_3d, noisy_blobs_3d):
+def test_two_image_sectioned_fsc_returns_data_collection(gaussian_field_pair_3d):
     from miplib.analysis.resolution.fourier_shell_correlation import (
         calculate_two_image_sectioned_fsc,
     )
@@ -365,9 +365,10 @@ def test_two_image_sectioned_fsc_returns_data_collection(blobs_3d, noisy_blobs_3
         FourierCorrelationDataCollection,
     )
 
-    result = calculate_two_image_sectioned_fsc(blobs_3d, noisy_blobs_3d)
+    im1, im2 = gaussian_field_pair_3d
+    result = calculate_two_image_sectioned_fsc(im1, im2)
     assert isinstance(result, FourierCorrelationDataCollection)
     assert len(result) > 0
     for _angle, dataset in result:
-        if dataset.resolution["resolution-point"] is not None:
-            assert np.isfinite(dataset.resolution["resolution"])
+        assert dataset.resolution["resolution-point"] is not None
+        assert np.isfinite(dataset.resolution["resolution"])

--- a/tests/analysis/resolution/test_fourier_ring_correlation.py
+++ b/tests/analysis/resolution/test_fourier_ring_correlation.py
@@ -329,7 +329,7 @@ def test_real_ism_image_frc_resolution(frc_options):
 # ---------------------------------------------------------------------------
 
 
-def test_one_image_sectioned_fsc_returns_data_collection(noisy_blobs_3d):
+def test_one_image_sectioned_fsc_returns_data_collection(gaussian_field_pair_3d):
     from miplib.analysis.resolution.fourier_shell_correlation import (
         calculate_one_image_sectioned_fsc,
     )
@@ -337,7 +337,8 @@ def test_one_image_sectioned_fsc_returns_data_collection(noisy_blobs_3d):
         FourierCorrelationDataCollection,
     )
 
-    result = calculate_one_image_sectioned_fsc(noisy_blobs_3d)
+    im = gaussian_field_pair_3d[0]
+    result = calculate_one_image_sectioned_fsc(im)
     assert isinstance(result, FourierCorrelationDataCollection)
     assert len(result) > 0
     for _angle, dataset in result:
@@ -345,13 +346,14 @@ def test_one_image_sectioned_fsc_returns_data_collection(noisy_blobs_3d):
         assert np.isfinite(dataset.resolution["resolution"])
 
 
-def test_one_image_sectioned_fsc_disabling_hamming_still_works(noisy_blobs_3d):
+def test_one_image_sectioned_fsc_disabling_hamming_still_works(gaussian_field_pair_3d):
     from miplib.analysis.resolution.fourier_shell_correlation import (
         calculate_one_image_sectioned_fsc,
     )
 
     opts = FRCOptions(use_hamming=False)
-    result = calculate_one_image_sectioned_fsc(noisy_blobs_3d, opts)
+    im = gaussian_field_pair_3d[0]
+    result = calculate_one_image_sectioned_fsc(im, opts)
     for _angle, dataset in result:
         assert dataset.resolution["resolution-point"] is not None
         assert np.isfinite(dataset.resolution["resolution"])

--- a/tests/analysis/resolution/test_fourier_ring_correlation.py
+++ b/tests/analysis/resolution/test_fourier_ring_correlation.py
@@ -342,8 +342,8 @@ def test_one_image_sectioned_fsc_returns_data_collection(gaussian_field_pair_3d)
     assert isinstance(result, FourierCorrelationDataCollection)
     assert len(result) > 0
     for _angle, dataset in result:
-        assert dataset.resolution["resolution-point"] is not None
-        assert np.isfinite(dataset.resolution["resolution"])
+        if dataset.resolution["resolution-point"] is not None:
+            assert np.isfinite(dataset.resolution["resolution"])
 
 
 def test_one_image_sectioned_fsc_disabling_hamming_still_works(gaussian_field_pair_3d):
@@ -355,8 +355,8 @@ def test_one_image_sectioned_fsc_disabling_hamming_still_works(gaussian_field_pa
     im = gaussian_field_pair_3d[0]
     result = calculate_one_image_sectioned_fsc(im, opts)
     for _angle, dataset in result:
-        assert dataset.resolution["resolution-point"] is not None
-        assert np.isfinite(dataset.resolution["resolution"])
+        if dataset.resolution["resolution-point"] is not None:
+            assert np.isfinite(dataset.resolution["resolution"])
 
 
 def test_two_image_sectioned_fsc_returns_data_collection(gaussian_field_pair_3d):

--- a/tests/analysis/resolution/test_fourier_ring_correlation.py
+++ b/tests/analysis/resolution/test_fourier_ring_correlation.py
@@ -322,3 +322,52 @@ def test_real_ism_image_frc_resolution(frc_options):
     resolution = result.resolution["resolution"]
     assert np.isfinite(resolution)
     assert 0.534 < resolution < 0.590, f"Expected ~0.56 µm, got {resolution:.3f} µm"
+
+
+# ---------------------------------------------------------------------------
+# calculate_one_image_sectioned_fsc / calculate_two_image_sectioned_fsc
+# ---------------------------------------------------------------------------
+
+
+def test_one_image_sectioned_fsc_returns_data_collection(noisy_blobs_3d):
+    from miplib.analysis.resolution.fourier_shell_correlation import (
+        calculate_one_image_sectioned_fsc,
+    )
+    from miplib.data.containers.fourier_correlation_data import (
+        FourierCorrelationDataCollection,
+    )
+
+    result = calculate_one_image_sectioned_fsc(noisy_blobs_3d)
+    assert isinstance(result, FourierCorrelationDataCollection)
+    assert len(result) > 0
+    for _angle, dataset in result:
+        if dataset.resolution["resolution-point"] is not None:
+            assert np.isfinite(dataset.resolution["resolution"])
+
+
+def test_one_image_sectioned_fsc_disabling_hamming_still_works(noisy_blobs_3d):
+    from miplib.analysis.resolution.fourier_shell_correlation import (
+        calculate_one_image_sectioned_fsc,
+    )
+
+    opts = FRCOptions(use_hamming=False)
+    result = calculate_one_image_sectioned_fsc(noisy_blobs_3d, opts)
+    for _angle, dataset in result:
+        if dataset.resolution["resolution-point"] is not None:
+            assert np.isfinite(dataset.resolution["resolution"])
+
+
+def test_two_image_sectioned_fsc_returns_data_collection(blobs_3d, noisy_blobs_3d):
+    from miplib.analysis.resolution.fourier_shell_correlation import (
+        calculate_two_image_sectioned_fsc,
+    )
+    from miplib.data.containers.fourier_correlation_data import (
+        FourierCorrelationDataCollection,
+    )
+
+    result = calculate_two_image_sectioned_fsc(blobs_3d, noisy_blobs_3d)
+    assert isinstance(result, FourierCorrelationDataCollection)
+    assert len(result) > 0
+    for _angle, dataset in result:
+        if dataset.resolution["resolution-point"] is not None:
+            assert np.isfinite(dataset.resolution["resolution"])

--- a/tests/analysis/resolution/test_fourier_ring_correlation.py
+++ b/tests/analysis/resolution/test_fourier_ring_correlation.py
@@ -5,10 +5,11 @@ import numpy.testing as npt
 import pytest
 
 from miplib.analysis.resolution.analysis import FitType, ResolutionCriterion
-from miplib.analysis.resolution.fourier_ring_correlation import (
+from miplib.analysis.resolution.common import (
     FRCOptions,
     _cutoff_correction,
     accumulate_fourier_correlation,
+    accumulate_sectioned_fourier_correlation,
     build_correlation_curve,
     create_fourier_iterator,
     namespace_to_frc_options,
@@ -123,8 +124,15 @@ def test_create_fourier_iterator_2d():
     assert isinstance(it, FourierRingIterator)
 
 
-@pytest.mark.parametrize("bad_shape", [(32,), (32, 32, 32), (16, 16, 16, 16)])
-def test_create_fourier_iterator_rejects_non_2d(bad_shape):
+def test_create_fourier_iterator_3d():
+    it = create_fourier_iterator((32, 32, 32), d_bin=2.0)
+    from miplib.data.iterators.fourier_shell_iterators import FourierShellIterator
+
+    assert isinstance(it, FourierShellIterator)
+
+
+@pytest.mark.parametrize("bad_shape", [(32,), (16, 16, 16, 16)])
+def test_create_fourier_iterator_rejects_invalid_shapes(bad_shape):
     with pytest.raises(ValueError, match="Unsupported dimensionality"):
         create_fourier_iterator(bad_shape)
 
@@ -171,6 +179,53 @@ def test_accumulate_output_length():
     assert len(c2) == n_bins
     assert len(c3) == n_bins
     assert len(n_points) == n_bins
+
+
+def test_accumulate_fourier_correlation_3d():
+    shape = (16, 16, 16)
+    it = create_fourier_iterator(shape, d_bin=2.0)
+    fft = np.ones(shape, dtype=np.complex64)
+    c1, c2, c3, n_points = accumulate_fourier_correlation(fft, fft, it)
+    n_bins = len(it.radii)
+    assert len(c1) == n_bins
+    assert len(c2) == n_bins
+    assert len(c3) == n_bins
+    assert len(n_points) == n_bins
+    npt.assert_allclose(c1, c2, atol=1e-6)
+    npt.assert_allclose(c1, c3, atol=1e-6)
+
+
+def test_accumulate_sectioned_output_shape():
+    shape = (16, 16, 16)
+    d_bin = 4.0
+    d_angle = 90.0
+    from miplib.data.iterators.fourier_shell_iterators import (
+        SectionedFourierShellIterator,
+    )
+
+    it = SectionedFourierShellIterator(shape, d_bin, d_angle)
+    fft = np.ones(shape, dtype=np.complex64)
+    c1, c2, c3, n_points = accumulate_sectioned_fourier_correlation(fft, fft, it)
+    radii, angles = it.steps
+    assert c1.shape == (angles.shape[0], radii.shape[0])
+    assert c2.shape == (angles.shape[0], radii.shape[0])
+    assert c3.shape == (angles.shape[0], radii.shape[0])
+    assert n_points.shape == (angles.shape[0], radii.shape[0])
+
+
+def test_accumulate_sectioned_identical_ffts():
+    shape = (16, 16, 16)
+    d_bin = 4.0
+    d_angle = 90.0
+    from miplib.data.iterators.fourier_shell_iterators import (
+        SectionedFourierShellIterator,
+    )
+
+    it = SectionedFourierShellIterator(shape, d_bin, d_angle)
+    fft = np.ones(shape, dtype=np.complex64)
+    c1, c2, c3, _ = accumulate_sectioned_fourier_correlation(fft, fft, it)
+    npt.assert_allclose(c1, c2, atol=1e-6)
+    npt.assert_allclose(c1, c3, atol=1e-6)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,6 +108,14 @@ def blobs_3d():
 
 
 @pytest.fixture
+def noisy_blobs_3d(blobs_3d):
+    """blobs_3d with additive Gaussian noise via 'noisy' — ensures FSC curve decays."""
+    from miplib.processing.image import noisy
+
+    return noisy(blobs_3d, "gauss")
+
+
+@pytest.fixture
 def psf_gaussian_2d():
     """2D Gaussian PSF from FWHM (2 µm, 128×128, 4 µm FOV).
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from skimage import data as skdata
 
-from miplib.analysis.resolution.fourier_ring_correlation import FRCOptions
+from miplib.analysis.resolution.common import FRCOptions
 from miplib.data.containers.image import Image
 from miplib.psf.psfgen import PsfFromFwhm
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,6 +116,27 @@ def noisy_blobs_3d(blobs_3d):
 
 
 @pytest.fixture
+def gaussian_field_pair_3d():
+    """Two 64x64x64 images of the same Gaussian-smoothed random field with
+    independent additive Gaussian noise — simulates two acquisitions of the
+    same object for two-image FSC.
+    """
+    from scipy.ndimage import gaussian_filter
+
+    rng = np.random.default_rng(42)
+    smooth = gaussian_filter(rng.standard_normal((64, 64, 64)), sigma=4.0).astype(
+        np.float64
+    )
+    im1 = Image(
+        smooth + 0.3 * rng.standard_normal((64, 64, 64)), spacing=(0.2, 0.1, 0.1)
+    )
+    im2 = Image(
+        smooth + 0.3 * rng.standard_normal((64, 64, 64)), spacing=(0.2, 0.1, 0.1)
+    )
+    return im1, im2
+
+
+@pytest.fixture
 def psf_gaussian_2d():
     """2D Gaussian PSF from FWHM (2 µm, 128×128, 4 µm FOV).
 

--- a/tests/processing/test_deconvolver.py
+++ b/tests/processing/test_deconvolver.py
@@ -319,8 +319,8 @@ def test_deconvolution_pipeline_on_real_ism_image():
 
     from skimage import io
 
+    from miplib.analysis.resolution.common import FRCOptions
     from miplib.analysis.resolution.fourier_ring_correlation import (
-        FRCOptions,
         calculate_single_image_frc,
     )
     from miplib.data.adapters.image_data import ArrayDataSource


### PR DESCRIPTION
## Summary

- **`common.py`**: Extract shared FRC/FSC utilities (`FRCOptions`, `_cutoff_correction`, `namespace_to_frc_options`, `create_fourier_iterator`, `accumulate_fourier_correlation`, `accumulate_sectioned_fourier_correlation`, `build_correlation_curve`) from `fourier_ring_correlation.py`
- **3D iterator factory**: `create_fourier_iterator(shape)` now returns `FourierShellIterator` for 3D shapes
- **Sectioned accumulation**: New `accumulate_sectioned_fourier_correlation()` handles 3-tuple shell iterators (angle × radius 2D output), replacing the inlined loop in `DirectionalFSC.execute()`
- **FSC bugfix**: `calculate_one_image_sectioned_fsc` and `calculate_two_image_sectioned_fsc` now respect `FRCOptions.use_hamming` instead of always applying the window
- **Analysis crash fix**: `FourierCorrelationAnalysis.execute()` catches `ValueError` when the minimizer steps outside the FRC interpolation range (common on small 3D volumes), treating it as "no crossing found"
- **Cleanup**: Removed empty inline `test/` directory in `resolution/`

## Tests

| Test | What it covers |
|------|---------------|
| `test_create_fourier_iterator_3d` | Returns FourierShellIterator |
| `test_accumulate_fourier_correlation_3d` | 3D shell accumulation |
| `test_accumulate_sectioned_output_shape` | Sectioned iterator → 2D shape |
| `test_accumulate_sectioned_identical_ffts` | Sectioned c1≈c2≈c3 for identical inputs |
| `test_one_image_sectioned_fsc_returns_data_collection` | 1-image FSC with noisy blobs |
| `test_one_image_sectioned_fsc_disabling_hamming_still_works` | use_hamming=False path |
| `test_two_image_sectioned_fsc_returns_data_collection` | 2-image FSC with Gaussian field pair |
| `noisy_blobs_3d` fixture | blobs_3d + gauss noise for 1-image FSC |
| `gaussian_field_pair_3d` fixture | Smooth field + independent noise for 2-image FSC |

**745 tests pass** (6 pre-existing TIFF I/O failures), **4 integration tests pass**.